### PR TITLE
Code cleaning and optimization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ NCDFLIB = '-L$(NCDF)/lib -lnetcdf -lnetcdff'
 NCDFINC = -I$(NCDF)/include
 LIBS = $(NCDFLIB)
 F90 = f95
-MPIF90 = mpif90 #f95
+MPIF90 = f95
 FFLAGS = -O2 -fdefault-real-8 ${NCDFINC} #-fbounds-check  -g -fcheck=all  -Wall -Wtabs -fbacktrace -ffpe-trap=invalid,zero,overflow
 F77FLAGS = -O2 #-fbounds-check  -ffpe-trap=invalid,zero,overflow
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ NCDFLIB = '-L$(NCDF)/lib -lnetcdf -lnetcdff'
 NCDFINC = -I$(NCDF)/include
 LIBS = $(NCDFLIB)
 F90 = f95
-MPIF90 = f95
+MPIF90 = mpif90 #f95
 FFLAGS = -O2 -fdefault-real-8 ${NCDFINC} #-fbounds-check  -g -fcheck=all  -Wall -Wtabs -fbacktrace -ffpe-trap=invalid,zero,overflow
 F77FLAGS = -O2 #-fbounds-check  -ffpe-trap=invalid,zero,overflow
 

--- a/script/postp_uclales-salsa3.py
+++ b/script/postp_uclales-salsa3.py
@@ -6,7 +6,7 @@ def openr(filepref,ff):
 def openw(filepref):
     import netCDF4 as nc
     fname = '%s_pp.nc' % (filepref)
-    return nc.Dataset(fname,'w')
+    return nc.Dataset(fname,'w',format='NETCDF3_CLASSIC')
 
 def opena(filepref):
     import netCDF4 as nc

--- a/src/Makefile
+++ b/src/Makefile
@@ -69,11 +69,11 @@ init.o: grid.o stat.o util.o defs.o step.o sgsm.o thrm.o  \
 rfft.o:
 rad_rndnmb.o:
 rad_solver.o: defs.o
-rad_corkds.o: defs.o
+rad_corkds.o: defs.o $(seqmpi:.f90=.o)
 rad_cldwtr.o: defs.o rad_corkds.o
 rad_d4strm.o: defs.o rad_solver.o rad_rndnmb.o \
 	      rad_corkds.o rad_cldwtr.o
-rad_driver.o: defs.o rad_d4strm.o
+rad_driver.o: defs.o rad_d4strm.o $(seqmpi:.f90=.o)
 $(seqmpi:.f90=.o):
 mo_salsa_driver.o: mo_submctl.o mo_salsa.o class_componentIndex.o
 mo_constants.o:

--- a/src/src_LES/LES.f90
+++ b/src/src_LES/LES.f90
@@ -19,6 +19,8 @@
 !
 program ucla_les
 
+  use mpi_interface, ONLY : myid
+
   implicit none
 
   real :: t1, t2
@@ -27,8 +29,10 @@ program ucla_les
   call driver
   call cpu_time(t2)
 
-  print "(/,' ',49('-')/,' ',A16,F10.1,' s')", '  Execution time: ', t2-t1
-  stop ' ..... Normal termination'
+  if (myid == 0) THEN
+    print "(/,' ',49('-')/,' ',A16,F10.1,' s')", '  Execution time: ', t2-t1
+    stop ' ..... Normal termination'
+  ENDIF
 
 contains
 

--- a/src/src_LES/LES.f90
+++ b/src/src_LES/LES.f90
@@ -88,7 +88,7 @@ contains
     use srfc, only : isfctyp, zrough, ubmin, dthcon, drtcon
     use step, only : timmax, istpfl, corflg, outflg, frqanl, frqhis,          &
          strtim, radfrq, cntlat
-    use grid, only : ver, deltaz, deltay, deltax, nzp, nyp, nxp, nxpart, &
+    use grid, only : deltaz, deltay, deltax, nzp, nyp, nxp, nxpart, &
          dtlong, dzrat,dzmax, th00, umean, vmean, isgstyp, naddsc, level,     &
          filprf, expnme, iradtyp, igrdtyp, nfpt, distim, runtype, CCN,        &
          Tspinup,sst, lbinanl
@@ -99,7 +99,7 @@ contains
                      div, case_name, &     ! Divergence, forcing case name
                      sfc_albedo            ! Surface albedo
     USE mcrp, ONLY : sed_aero, sed_cloud, sed_precp, sed_ice, sed_snow
-    use mpi_interface, only : myid, appl_abort
+    use mpi_interface, only : myid, appl_abort, ver, author
 
     implicit none
 
@@ -131,10 +131,10 @@ contains
          Tspinup, lbinanl,          & ! Length of spinup period in seconds
          radsounding, div, case_name, & ! Name of the radiation sounding file, divergence for LEVEL 4
          sfc_albedo,                  & ! Surface albedo
-         sed_aero, sed_cloud, sed_precp, sed_ice, sed_snow
+         sed_aero, sed_cloud, sed_precp, sed_ice, sed_snow ! Sedimentation (T/F)
 
     namelist /version/  &
-         ver
+         ver, author        ! Information about UCLALES-SALSA version and author
 
     ps       = 0.
     ts       = th00
@@ -183,7 +183,7 @@ contains
     end if
 
 600 format(//' ',49('-')/,' ',/,'  Initial Experiment: ',A50 &
-         /,'  Final Time:         ',F7.1,' s'              )
+         /,'  Final Time:         ',F8.1,' s'              )
 601 format(//' ',49('-')/,' ',/,'  Restart Experiment: ',A50 &
          /,'  Restart File: ',A30,                           &
          /,'  Final Time: ',F10.1,' s'              )

--- a/src/src_LES/advf.f90
+++ b/src/src_LES/advf.f90
@@ -33,10 +33,10 @@ contains
   !
   subroutine fadvect
     use grid, only : a_up, a_vp, a_wp, a_uc, a_vc, a_wc, a_rc, a_qp, newsclr  &
-         , a_scr1, a_scr2, nscl, a_sp, a_st, nxyzp,dn0 , nxp, nyp, nzp, dtlt  &
+         , a_scr1, a_scr2, nscl, a_sp, a_st, dn0 , nxp, nyp, nzp, dtlt  &
          , dzt, dzm, zt, dxi, dyi, level, isgstyp
     use stat, only      : sflg, updtst
-    use util, only      : atob, get_avg3
+    use util, only      : get_avg3
 
     real    :: v1da(nzp)
     integer :: n
@@ -45,7 +45,7 @@ contains
     ! diagnose liquid water flux
     !
     if (sflg .and. level > 1 .AND. level < 4) then
-       call atob(nxyzp,a_rc,a_scr1)
+       a_scr1=a_rc
        call add_vel(nzp,nxp,nyp,a_scr2,a_wp,a_wc,.false.)
        call mamaos(nzp,nxp,nyp,a_scr2,a_rc,a_scr1,zt,dzm,dn0,dtlt,.false.)
        call get_avg3(nzp,nxp,nyp,a_scr2,v1da)
@@ -59,8 +59,8 @@ contains
     !
     do n=1,nscl
        call newsclr(n)
-      IF ( ANY(a_sp /= 0.0 ) ) THEN ! TR added: no need to calculate advection for constant arrays (often just zeros)
-       call atob(nxyzp,a_sp,a_scr1)
+      IF ( ANY(a_sp /= 0.0 ) ) THEN ! TR added: no need to calculate advection for zero arrays
+       a_scr1=a_sp
 
        if (isgstyp > 1 .and. associated(a_qp,a_sp)) then
           iw= .true.
@@ -98,10 +98,10 @@ contains
   SUBROUTINE newdroplet(pactmask)
     USE mo_submctl, ONLY : ncld,nbins,ica,fca,eps
     use grid, only : nxp,nyp,nzp,dzt,            &
-                     a_up,a_wp,a_wc,  &
+                     a_wp,a_wc,  &
                      a_naerop, a_naerot, a_maerop, a_maerot,  &
                      a_ncloudt, a_mcloudt,  &
-                     a_nactd,  a_vactd,  a_rp,     a_rt,      &
+                     a_nactd,  a_vactd,  a_rt,      &
                      prtcl
     USE class_ComponentIndex, ONLY : GetNcomp, GetIndex
     IMPLICIT NONE

--- a/src/src_LES/forc.f90
+++ b/src/src_LES/forc.f90
@@ -29,6 +29,7 @@ module forc
                                                             ! from the NAMELIST
   REAL :: sfc_albedo = 0.05
   REAL  :: div = 0.
+  LOGICAL :: useMcICA = .TRUE.
 
 contains
   !
@@ -47,8 +48,8 @@ contains
     real, optional, intent (in) :: time_in, cntlat, sst
 
     real :: xka, fr0, fr1, xref1, xref2
-    REAL :: zrv(nzp,nxp,nyp), znc(nzp,nxp,nyp)
-         
+    REAL :: znc(nzp,nxp,nyp)
+
     ! DIVERGENCE GIVEN FROM NAMELIST
     if (trim(case_name) == 'atex') then
        xka = 130.
@@ -101,7 +102,7 @@ contains
 
              call d4stream(nzp, nxp, nyp, cntlat, time_in, sst, sfc_albedo, CCN,&
                   dn0, pi0, pi1, dzt, a_pexnr, a_scr1, a_rv, a_rc, a_tt,  &
-                  a_rflx, a_sflx, albedo, rr=a_rpp,radsounding=radsounding)
+                  a_rflx, a_sflx, albedo, rr=a_rpp,radsounding=radsounding,useMcICA=useMcICA)
 
           ELSE IF (level < 3) THEN
 
@@ -109,7 +110,7 @@ contains
              xref2 = 0.
              call d4stream(nzp, nxp, nyp, cntlat, time_in, sst, sfc_albedo, CCN,&
                   dn0, pi0, pi1, dzt, a_pexnr, a_scr1, a_rv, a_rc, a_tt,  &
-                  a_rflx, a_sflx, albedo,radsounding=radsounding)
+                  a_rflx, a_sflx, albedo,radsounding=radsounding,useMcICA=useMcICA)
              xref1 = xref1 + a_sflx(nzp,3,3)/albedo(3,3)
              xref2 = xref2 + a_sflx(nzp,3,3)
              albedo(3,3) = xref2/xref1
@@ -121,7 +122,7 @@ contains
 
              CALL d4stream(nzp, nxp, nyp, cntlat, time_in, sst, sfc_albedo, CCN,&
                   dn0, pi0, pi1, dzt, a_pexnr, a_scr1, a_rp, a_rc, a_tt,  &
-                  a_rflx, a_sflx, albedo, rr = a_srp, CDNC=znc, radsounding=radsounding) 
+                  a_rflx, a_sflx, albedo, rr = a_srp, CDNC=znc, radsounding=radsounding,useMcICA=useMcICA) 
 
           END IF
 

--- a/src/src_LES/grid.f90
+++ b/src/src_LES/grid.f90
@@ -24,8 +24,7 @@ module grid
   USE class_componentIndex, ONLY : componentIndex
 
   implicit none
-  !                         
-  CHARACTER(len=20)  :: ver = "latest"     ! Model version - you have to use git for this to work right
+  !
   integer           :: nxp = 132           ! number of x points
   integer           :: nyp = 132           ! number of y points
   integer           :: nzp = 105           ! number of z points
@@ -128,7 +127,6 @@ module grid
   REAL, POINTER :: a_gaerop(:,:,:,:), a_gaerot(:,:,:,:)
 
   ! Diagnostic tracers
-  REAL, ALLOCATABLE :: a_rhop(:,:,:,:)
   REAL, ALLOCATABLE :: a_Rawet(:,:,:,:), a_Radry(:,:,:,:),  &
                        a_Rcwet(:,:,:,:), a_Rcdry(:,:,:,:),  &
                        a_Rpwet(:,:,:,:), a_Rpdry(:,:,:,:),  &
@@ -180,9 +178,6 @@ module grid
   real, allocatable :: wt_sfc(:,:)
   real, allocatable :: wq_sfc(:,:)
   real, allocatable :: precip(:,:,:), snowin(:,:,:), albedo(:,:)
-  !real, allocatable :: ra(:,:)
-
-  !real, allocatable  :: zvar(:,:,:,:) ! for Salsa output .. by Zubair
 
   ! Juha:
   ! Diagnostic variables needed to track mass conservation (of water).
@@ -218,7 +213,7 @@ contains
 
 
     integer :: memsize
-    INTEGER :: ii,zz
+    INTEGER :: zz
     INTEGER :: nc
 
     ! Juha: Number of prognostic tracers for SALSA
@@ -281,7 +276,7 @@ contains
     a_scr4(:,:,:) = 0.
     a_scr5(:,:,:) = 0.
     a_scr6(:,:,:) = 0.
-    memsize = memsize + 6.*nxyzp
+    memsize = memsize + 6*nxyzp
 
     allocate (a_temp0(nzp,nxp,nyp))
     a_temp0(nzp,nxp,nyp) = 0.
@@ -338,7 +333,7 @@ contains
                  a_Rawet(nzp,nxp,nyp,nbins),a_Radry(nzp,nxp,nyp,nbins),          &
                  a_Rcwet(nzp,nxp,nyp,ncld), a_Rcdry(nzp,nxp,nyp,ncld),           &
                  a_Rpwet(nzp,nxp,nyp,nprc), a_Rpdry(nzp,nxp,nyp,nprc),           &
-                 a_rhop(nzp,nxp,nyp,nbins), a_rh(nzp,nxp,nyp),a_dn(nzp,nxp,nyp), &
+                 a_rh(nzp,nxp,nyp),a_dn(nzp,nxp,nyp), &
                  a_nactd(nzp,nxp,nyp,ncld), a_vactd(nzp,nxp,nyp,(nc+1)*ncld)  )
 
        a_rc(:,:,:) = 0.
@@ -346,7 +341,6 @@ contains
        a_snrp(:,:,:) = 0.
        a_Rawet(:,:,:,:) = 1.e-10
        a_Radry(:,:,:,:) = 1.e-10
-       a_rhop(:,:,:,:) = 0.
        a_Rcwet(:,:,:,:) = 1.e-10
        a_Rcdry(:,:,:,:) = 1.e-10
        a_Rpwet(:,:,:,:) = 1.e-10
@@ -390,7 +384,7 @@ contains
           a_qt=>a_sclrt(:,:,:,nscl - nsalsa)
        end if
 
-       !JT: Set the pointers for prognostic SALSA variables
+       !JT: Set the pointers for prognostic SALSA variables (levels 4 & 5)
        zz = nscl-nsalsa
        a_naerop => a_sclrp(:,:,:,zz+1:zz+nbins)
        a_naerot => a_sclrt(:,:,:,zz+1:zz+nbins)
@@ -419,7 +413,7 @@ contains
        a_gaerop => a_sclrp(:,:,:,zz+1:zz+5)
        a_gaerot => a_sclrt(:,:,:,zz+1:zz+5)
 
-       !!huomhuom following added by Jaakko
+       ! Level 5
        zz = zz+5
        a_nicep => a_sclrp(:,:,:,zz+1:zz+nice)
        a_nicet => a_sclrt(:,:,:,zz+1:zz+nice)
@@ -466,7 +460,6 @@ contains
     ww_sfc(:,:)  = 0.
     wt_sfc(:,:) = 0.
     wq_sfc(:,:) = 0.
-    !ra(:,:) = 0.
     umean = 0.
     vmean = 0.
 
@@ -680,9 +673,9 @@ contains
   !
   subroutine init_anal(time)
 
-    use mpi_interface, only :myid
-    USE mo_submctl, ONLY : in1a,fn1a,in2a,fn2a,in2b,fn2b,ica,fca,icb,fcb,ira,fra, &
-                               iia,fia,iib,fib,isa,fsa
+    use mpi_interface, only :myid, ver, author
+    USE mo_submctl, ONLY : fn2a,fn2b,fca,fcb,fra, &
+                               fia,fib,fsa
     USE class_ComponentIndex, ONLY : IsUsed
     integer, parameter :: nnames = 24
     integer, parameter :: salsa_nn = 104
@@ -822,7 +815,7 @@ contains
     fname =  trim(filprf)
     if(myid == 0) print                                                  &
             "(//' ',49('-')/,' ',/,'   Initializing: ',A20)",trim(fname)
-    call open_nc( fname, expnme, time, (nxp-4)*(nyp-4), ncid0, nrec0)
+    call open_nc( fname, expnme, time, (nxp-4)*(nyp-4), ncid0, nrec0, ver, author)
 
     IF (level < 4 .OR. .NOT. lbinanl) THEN
        call define_nc( ncid0, nrec0, nvar0, sanal, n1=nzp, n2=nxp-4, n3=nyp-4)
@@ -858,7 +851,7 @@ contains
   ! ----------------------------------------------------------------------
   ! Subroutine Write_anal:  Writes the netcdf Analysis file
   !
-  ! Modified for level 4
+  ! Modified for levels 4 and 5
   ! Juha Tonttila, FMI, 2014
   !
   !
@@ -866,7 +859,7 @@ contains
     use netcdf
     use mpi_interface, only : myid, appl_abort
     USE class_ComponentIndex, ONLY : IsUsed
-    USE mo_submctl, ONLY : in1a,fn1a,in2a,fn2a,in2b,fn2b, &
+    USE mo_submctl, ONLY : in1a,fn2a,in2b,fn2b, &
                                ica,fca,icb,fcb,ira,fra,       &
                                iia,fia,iib,fib,isa,fsa,       &
                                aerobins, cloudbins, precpbins, &
@@ -881,7 +874,6 @@ contains
     REAL :: zsum(nzp,nxp,nyp) ! Juha: Helper for computing bulk output diagnostics
     REAL :: zvar(nzp,nxp,nyp)
 
-    !return
     icnt = (/nzp, nxp-4, nyp-4, 1/)
     icntaea = (/nzp,nxp-4,nyp-4, fn2a, 1 /)
     icntaeb = (/nzp,nxp-4,nyp-4, fn2b-fn2a, 1/)
@@ -898,8 +890,6 @@ contains
     i2 = nxp-2
     j1 = 3
     j2 = nyp-2
-
-    !WRITE(*,*) 'mmm', time, nrec0, sanal(1)
 
     iret = nf90_inq_varid(ncid0, sanal(1), VarID)
     iret = nf90_put_var(ncid0, VarID, time, start=(/nrec0/))
@@ -974,41 +964,28 @@ contains
             count=icnt)
 
     ELSE IF (level >= 4) THEN
-
-
-
        iret = nf90_inq_varid(ncid0, 'u0', VarID)
        iret = nf90_put_var(ncid0, VarID, u0, start = (/nrec0/))
-
        iret = nf90_inq_varid(ncid0, 'v0', VarID)
        iret = nf90_put_var(ncid0, VarID, v0, start = (/nrec0/))
-
        iret = nf90_inq_varid(ncid0, 'dn0', VarID)
        iret = nf90_put_var(ncid0, VarID, dn0, start = (/nrec0/))
-
-       !IF (.FALSE.) THEN
 
        iret = nf90_inq_varid(ncid0, 'u', VarID)
        iret = nf90_put_var(ncid0, VarID, a_up(:,i1:i2,j1:j2), start=ibeg,    &
             count=icnt)
-
        iret = nf90_inq_varid(ncid0, 'v', VarID)
        iret = nf90_put_var(ncid0, VarID, a_vp(:,i1:i2,j1:j2), start=ibeg,    &
             count=icnt)
-
        iret = nf90_inq_varid(ncid0, 'w', VarID)
        iret = nf90_put_var(ncid0, VarID, a_wp(:,i1:i2,j1:j2), start=ibeg,    &
             count=icnt)
-
        iret = nf90_inq_varid(ncid0, 't', VarID)
        iret = nf90_put_var(ncid0, VarID, a_theta(:,i1:i2,j1:j2), start=ibeg, &
             count=icnt)
-
        iret = nf90_inq_varid(ncid0, 'p', VarID)
        iret = nf90_put_var(ncid0, VarID, a_press(:,i1:i2,j1:j2), start=ibeg, &
             count=icnt)
-
-       !END IF
 
     END IF
 
@@ -1067,24 +1044,21 @@ contains
        END IF
        
        ! Total water mixing ratio
-       zvar(:,:,:) = 0.
-       zvar(:,:,:) = zvar(:,:,:) + a_rp(:,:,:) ! Water vapor
-       zvar(:,:,:) = zvar(:,:,:) + a_rc(:,:,:) ! Liquid water
-       zvar(:,:,:) = zvar(:,:,:) + a_srp(:,:,:) ! Rain
+       zvar(:,:,:) = a_rp(:,:,:) + &   ! Water vapor
+                         a_rc(:,:,:) + &   ! Liquid water
+                         a_srp(:,:,:)        ! Rain
        
        iret = nf90_inq_varid(ncid0,'q',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
             count=icnt)
        
        ! Liquid water mixing ratio
-       zvar(:,:,:) = 0.
        zvar(:,:,:) = a_rc(:,:,:)
        iret = nf90_inq_varid(ncid0,'l',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
             count=icnt)
        
        ! Rain water mixing ratio
-       zvar(:,:,:) = 0.
        zvar(:,:,:) = a_srp(:,:,:)
        iret = nf90_inq_varid(ncid0,'r',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1093,22 +1067,19 @@ contains
        IF ( level == 5) THEN !
           
           ! Total ice mixing ratio
-          zvar(:,:,:) = 0.
-          zvar(:,:,:) = zvar(:,:,:) + a_ri(:,:,:) ! Ice cloud content
-          zvar(:,:,:) = zvar(:,:,:) + a_srs(:,:,:) ! Snow
+          zvar(:,:,:) = a_ri(:,:,:) + & ! Ice cloud content
+                           a_srs(:,:,:)      ! Snow
           iret = nf90_inq_varid(ncid0,'f',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           ! Ice mixing ratio
-          zvar(:,:,:) = 0.
           zvar(:,:,:) = a_ri(:,:,:)
           iret = nf90_inq_varid(ncid0,'i',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           ! Snow ice mixing ratio
-          zvar(:,:,:) = 0.
           zvar(:,:,:) = a_srs(:,:,:)
           iret = nf90_inq_varid(ncid0,'s',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1116,10 +1087,8 @@ contains
        END IF
        
        ! Total number of cloud droplets
-       zvar(:,:,:) = 0.
-       zsum(:,:,:) = 0.
        CALL bulkNumc('cloud','a',zvar(:,:,:))
-       zsum = zsum + zvar
+       zsum = zvar
        CALL bulkNumc('cloud','b',zvar(:,:,:))
        zsum = zsum + zvar
        iret = nf90_inq_varid(ncid0,'S_Nc',VarID)
@@ -1139,14 +1108,12 @@ contains
        END IF
        
        ! Mean cloud droplet wet radius (regime A)
-       zvar(:,:,:) = 0.
        CALL meanRadius('cloud','a',zvar(:,:,:))
        iret = nf90_inq_varid(ncid0,'S_Rwca',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
             count=icnt)
        
        ! Mean cloud droplet wet radius (regime B)
-       zvar(:,:,:) = 0.
        CALL meanRadius('cloud','b',zvar(:,:,:))
        iret = nf90_inq_varid(ncid0,'S_Rwcb',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1165,7 +1132,6 @@ contains
        END IF
        
        ! Number of rain droplets
-       zvar(:,:,:) = 0.
        CALL bulkNumc('precp','a',zvar(:,:,:))
        iret = nf90_inq_varid(ncid0,'S_Np',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1179,7 +1145,6 @@ contains
        END IF
        
        ! Mean rain drop wet radius
-       zvar(:,:,:) = 0.
        CALL meanRadius('precp','a',zvar(:,:,:))
        iret = nf90_inq_varid(ncid0,'S_Rwpa',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg,  &
@@ -1193,14 +1158,12 @@ contains
        END IF
        
        ! Number of soluble aerosols (regime A)
-       zvar(:,:,:) = 0.
        CALL bulkNumc('aerosol','a',zvar(:,:,:))
        iret = nf90_inq_varid(ncid0,'S_Na',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
             count=icnt)
        
        ! Number of insoluble aerosols (regime B)
-       zvar(:,:,:) = 0.
        CALL bulkNumc('aerosol','b',zvar(:,:,:))
        iret = nf90_inq_varid(ncid0,'S_Nb',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1219,14 +1182,12 @@ contains
        END IF
        
        ! Mean aerosol wet radius (regime A)
-       zvar(:,:,:) = 0.
        CALL meanRadius('aerosol','a',zvar(:,:,:))
        iret = nf90_inq_varid(ncid0,'S_Rwaa',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg,  &
             count=icnt)
        
        ! Mean aerosol wet radius (regime B)
-       zvar(:,:,:) = 0.
        CALL meanRadius('aerosol','b',zvar(:,:,:))
        iret = nf90_inq_varid(ncid0,'S_Rwab',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg,  &
@@ -1246,10 +1207,8 @@ contains
        
        IF (level == 5) THEN
           ! Number of ice particles
-          zvar(:,:,:) = 0.
-          zsum(:,:,:) = 0.
           CALL bulkNumc('ice','a',zvar(:,:,:))
-          zsum = zsum + zvar
+          zsum = zvar
           CALL bulkNumc('ice','b',zvar(:,:,:))
           zsum = zsum + zvar
           iret = nf90_inq_varid(ncid0,'S_Nic',VarID)
@@ -1257,28 +1216,24 @@ contains
                count=icnt)
           
           ! Number of snow droplets
-          zvar(:,:,:) = 0.
           CALL bulkNumc('snow','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_Ns',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           ! Mean ice particle wet radius (a)
-          zvar(:,:,:) = 0.
           CALL meanRadius('ice','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_Rwia',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           ! Mean ice particle wet radius (b)
-          zvar(:,:,:) = 0.
           CALL meanRadius('ice','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_Rwib',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           ! Mean snow drop wet radius
-          zvar(:,:,:) = 0.
           CALL meanRadius('snow','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_Rwsa',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg,  &
@@ -1297,22 +1252,22 @@ contains
              
              ! Ice particle bin wet radius regime a
              iret = nf90_inq_varid(ncid0,'S_Rwiba',VarID)
-             iret = nf90_put_var(ncid0,VarID,a_Rcwet(:,i1:i2,j1:j2,iia%cur:fia%cur), &
+             iret = nf90_put_var(ncid0,VarID,a_Riwet(:,i1:i2,j1:j2,iia%cur:fia%cur), &
                   start=ibegsd,count=icntica)
              
              ! Ice particle bin wet radius regime b
              iret = nf90_inq_varid(ncid0,'S_Rwibb',VarID)
-             iret = nf90_put_var(ncid0,VarID,a_Rcwet(:,i1:i2,j1:j2,iib%cur:fib%cur), &
+             iret = nf90_put_var(ncid0,VarID,a_Riwet(:,i1:i2,j1:j2,iib%cur:fib%cur), &
                   start=ibegsd,count=icntica)
              
              ! Snow size distribution
              iret = nf90_inq_varid(ncid0,'S_Nsba',VarID)
-             iret = nf90_put_var(ncid0,VarID,a_nprecpp(:,i1:i2,j1:j2,ira:fra), &
+             iret = nf90_put_var(ncid0,VarID,a_nsnowp(:,i1:i2,j1:j2,isa:fsa), &
                   start=ibegsd,count=icntsna)
              
              ! Snow drop bin wet radius
              iret = nf90_inq_varid(ncid0,'S_Rwsba',VarID)
-             iret = nf90_put_var(ncid0,VarID,a_Rpwet(:,i1:i2,j1:j2,ira:fra),  &
+             iret = nf90_put_var(ncid0,VarID,a_Rswet(:,i1:i2,j1:j2,isa:fsa),  &
                   start=ibegsd,count=icntsna)
              
           END IF !(lbinanl)
@@ -1320,7 +1275,6 @@ contains
        END IF !level 5
 
        ! Number of newly activated
-       zvar(:,:,:) = 0.
        zvar(:,:,:) = SUM(a_nactd(:,:,:,:), DIM=4)
        iret = nf90_inq_varid(ncid0,'S_Nact',VarID)
        iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1330,47 +1284,37 @@ contains
        IF (IsUsed(prtcl,'SO4')) THEN
 
           ! --Sulphate (aerosol, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'SO4')) &
-               CALL bulkMixrat('SO4','aerosol','a',zvar(:,:,:))
+          CALL bulkMixrat('SO4','aerosol','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aSO4a',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
 
           ! --Sulphate (aerosol, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'SO4')) &
-               CALL bulkMixrat('SO4','aerosol','b',zvar(:,:,:))
+          CALL bulkMixrat('SO4','aerosol','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aSO4b',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           ! --Sulphate (clouds, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'SO4')) &
-               CALL bulkMixrat('SO4','cloud','a',zvar(:,:,:))
+          CALL bulkMixrat('SO4','cloud','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cSO4a',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           ! --Sulphate (clouds, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'SO4')) &
-               CALL bulkMixrat('SO4','cloud','b',zvar(:,:,:))
+          CALL bulkMixrat('SO4','cloud','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cSO4b',VarID)
           iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
 
           IF (level == 5) THEN
              ! --Sulphate (ice, regime A)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('SO4','ice','a',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iSO4a',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                   count=icnt)
              
              ! --Sulphate (ice, regime B)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('SO4','ice','b',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iSO4b',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1382,47 +1326,37 @@ contains
        IF (IsUSed(prtcl,'NH')) THEN
 
           !-- Ammonium (aerosol, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'NH')) &
-               CALL bulkMixrat('NH','aerosol','a',zvar(:,:,:))
+          CALL bulkMixrat('NH','aerosol','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aNH3a',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Ammonium (aerosol, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'NH')) &
-               CALL bulkMixrat('NH','aerosol','b',zvar(:,:,:))
+          CALL bulkMixrat('NH','aerosol','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aNH3b',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Ammonium (clouds, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'NH')) &
-               CALL bulkMixrat('NH','cloud','a',zvar(:,:,:))
+          CALL bulkMixrat('NH','cloud','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cNH3a',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Ammonium (clouds, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'NH')) &
-               CALL bulkMixrat('NH','cloud','b',zvar(:,:,:))
+          CALL bulkMixrat('NH','cloud','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cNH3b',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
 
           IF (level == 5) THEN
              ! --Ammonium (ice, regime A)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('NH','ice','a',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iNHa',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                   count=icnt)
              
              ! --Ammonium (ice, regime B)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('NH','ice','b',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iNHb',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1434,47 +1368,37 @@ contains
        IF (IsUsed(prtcl,'NO')) THEN
 
           !-- Nitrate (aerosol, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'NO')) &
-               CALL bulkMixrat('NO','aerosol','a',zvar(:,:,:))
+          CALL bulkMixrat('NO','aerosol','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aNO3a',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Nitrate (aerosol, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'NO')) &
-               CALL bulkMixrat('NO','aerosol','b',zvar(:,:,:))
+          CALL bulkMixrat('NO','aerosol','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aNO3b',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Nitrate (clouds, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'NO')) &
-               CALL bulkMixrat('NO','cloud','a',zvar(:,:,:))
+          CALL bulkMixrat('NO','cloud','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cNO3a',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Nitrate (clouds, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'NO')) &
-               CALL bulkMixrat('NO','cloud','b',zvar(:,:,:))
+          CALL bulkMixrat('NO','cloud','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cNO3b',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           IF (level == 5) THEN
              ! --Nitrate (ice, regime A)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('NO','ice','a',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iNOa',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                   count=icnt)
              
              ! --Nitrate (ice, regime B)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('NO','ice','b',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iNOb',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1486,47 +1410,37 @@ contains
        IF (IsUsed(prtcl,'OC')) THEN
         
           !-- Organic Carbon (aerosol, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'OC')) &
-               CALL bulkMixrat('OC','aerosol','a',zvar(:,:,:))
+          CALL bulkMixrat('OC','aerosol','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aOCa',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Organic Carbon (aerosol, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'OC')) &
-               CALL bulkMixrat('OC','aerosol','b',zvar(:,:,:))
+          CALL bulkMixrat('OC','aerosol','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aOCb',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Organic Carbon (clouds, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'OC')) &
-               CALL bulkMixrat('OC','cloud','a',zvar(:,:,:))
+          CALL bulkMixrat('OC','cloud','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cOCa',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Organic Carbon (clouds, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'OC')) &
-               CALL bulkMixrat('OC','cloud','b',zvar(:,:,:))
+          CALL bulkMixrat('OC','cloud','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cOCb',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           IF (level == 5) THEN
              ! --Organic Carbon (ice, regime A)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('OC','ice','a',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iOCa',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                   count=icnt)
              
              ! --Organic Carbon (ice, regime B)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('OC','ice','b',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iOCb',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1538,47 +1452,37 @@ contains
        IF (IsUsed(prtcl,'BC')) THEN
 
           !-- Black Carbon (aerosol, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'BC')) &
-               CALL bulkMixrat('BC','aerosol','a',zvar(:,:,:))
+          CALL bulkMixrat('BC','aerosol','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aBCa',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Black Carbon (aerosol, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'BC')) &
-               CALL bulkMixrat('BC','aerosol','b',zvar(:,:,:))
+          CALL bulkMixrat('BC','aerosol','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aBCb',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Black Carbon (clouds, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'BC')) &
-               CALL bulkMixrat('BC','cloud','a',zvar(:,:,:))
+          CALL bulkMixrat('BC','cloud','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cBCa',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Black Carbon (clouds, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'BC')) &
-               CALL bulkMixrat('BC','cloud','b',zvar(:,:,:))
+          CALL bulkMixrat('BC','cloud','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cBCb',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
 
           IF (level == 5) THEN
              ! --Black Carbon (ice, regime A)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('BC','ice','a',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iBCa',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                   count=icnt)
              
              ! --Black Carbon (ice, regime B)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('BC','ice','b',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iBCb',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1590,47 +1494,37 @@ contains
        IF (IsUsed(prtcl,'DU')) THEN
 
           !-- Dust (aerosol, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'DU')) &
-               CALL bulkMixrat('DU','aerosol','a',zvar(:,:,:))
+          CALL bulkMixrat('DU','aerosol','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aDUa',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Dust (aerosol, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'DU')) &
-               CALL bulkMixrat('DU','aerosol','b',zvar(:,:,:))
+          CALL bulkMixrat('DU','aerosol','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aDUb',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Dust (clouds, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'DU')) &
-               CALL bulkMixrat('DU','cloud','a',zvar(:,:,:))
+          CALL bulkMixrat('DU','cloud','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cDUa',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Dust (clouds, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'DU')) &
-               CALL bulkMixrat('DU','cloud','b',zvar(:,:,:))
+          CALL bulkMixrat('DU','cloud','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cDUb',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           IF (level == 5) THEN
              ! --Dust (ice, regime A)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('DU','ice','a',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iDUa',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                   count=icnt)
              
              ! --Dust (ice, regime B)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('DU','ice','b',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iDUb',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1642,47 +1536,37 @@ contains
        IF (IsUsed(prtcl,'SS')) THEN
 
           !-- Sea Salt (aerosol, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'SS')) &
-               CALL bulkMixrat('SS','aerosol','a',zvar(:,:,:))
+          CALL bulkMixrat('SS','aerosol','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aSSa',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Sea Salt (aerosol, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'SS')) &
-               CALL bulkMixrat('SS','aerosol','b',zvar(:,:,:))
+          CALL bulkMixrat('SS','aerosol','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_aSSb',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Sea Salt (aerosol, regime A)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'SS')) &
-               CALL bulkMixrat('SS','cloud','a',zvar(:,:,:))
+          CALL bulkMixrat('SS','cloud','a',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cSSa',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           !-- Sea Salt (aerosol, regime B)
-          zvar(:,:,:) = 0.
-          IF (IsUsed(prtcl,'SS')) &
-               CALL bulkMixrat('SS','cloud','b',zvar(:,:,:))
+          CALL bulkMixrat('SS','cloud','b',zvar(:,:,:))
           iret = nf90_inq_varid(ncid0,'S_cSSb',VarID)
           iret = nf90_put_var(ncid0,Varid,zvar(:,i1:i2,j1:j2),start=ibeg, &
                count=icnt)
           
           IF (level == 5) THEN
              ! -- Sea Salt (ice, regime A)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('SS','ice','a',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iSSa',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
                   count=icnt)
              
              ! -- Sea Salt (ice, regime B)
-             zvar(:,:,:) = 0.
              CALL bulkMixrat('SS','ice','b',zvar(:,:,:))
              iret = nf90_inq_varid(ncid0,'S_iSSb',VarID)
              iret = nf90_put_var(ncid0,VarID,zvar(:,i1:i2,j1:j2),start=ibeg, &
@@ -1813,7 +1697,7 @@ contains
           call appl_abort(-1)
        end if
 
-       read (10) xt, xm, yt, ym, zt, zm, dn0, th0, u0, v0, pi0, pi1, rt0, psrf
+       read (10) xt, xm, yt, ym, zt, zm, dn0, th0, u0, v0, pi0, pi1, rt0, psrf,sst,W1,W2,W3
 
        read (10) a_ustar, a_tstar, a_rstar
 
@@ -1901,9 +1785,6 @@ contains
   ! in aerosol particles or hydrometeors
   !
   ! Juha Tonttila, FMI, 2015
-  !
-
-  ! Juha Tonttila, FMI, 2015
   ! Jaakko Ahola, FMI, 2015
   SUBROUTINE bulkMixrat(icomp,ipart,itype,mixrat)
     USE mo_submctl, ONLY : ncld,nbins,nprc,   &
@@ -1913,57 +1794,25 @@ contains
                                iia,fia,iib,fib,   &
                                isa,fsa,           &
                                in1a,in2b,         &
-                               fn2a,fn2b,         &
+                               fn2a,fn2b
 
-                               rhosu,rhono,rhonh, &
-                               rhooc,rhobc,rhoss, &
-                               rhodu,rhowa
     USE class_ComponentIndex, ONLY : GetIndex, IsUsed
 
     CHARACTER(len=*), INTENT(in) :: icomp  ! This should be either:
                                            ! SO4,OC,NO,NH,BC,DU,SS,H2O.
 
     CHARACTER(len=*), INTENT(in) :: ipart  ! This should be either:
-                                           ! aerosol,cloud,rain
+                                           ! aerosol,cloud,rain,ice,snow
     CHARACTER(len=*), INTENT(in) :: itype  ! Select bin regime: a or b
 
     REAL, INTENT(out) :: mixrat(nzp,nxp,nyp)
 
     INTEGER :: istr,iend, mm
-    REAL :: zrho
 
     mixrat = 0.
 
     ! Determine multipliers
-    ! zrho not needed anymore, should be removed
-    IF (icomp == 'SO4' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhosu
-    ELSE IF (icomp == 'OC' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhooc
-    ELSE IF (icomp == 'BC ' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhobc
-    ELSE IF (icomp == 'DU' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhodu
-    ELSE IF (icomp == 'SS' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhoss
-    ELSE IF (icomp == 'NO' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhono
-    ELSE IF (icomp == 'NH' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhonh
-    ELSE IF (icomp == 'H2O') THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhowa
-    ELSE
-       WRITE(*,*) 'bulkMixrat: invalid species ',icomp
-       STOP
-    END IF
+    mm = GetIndex(prtcl,icomp)
 
     ! Given in kg/kg
     SELECT CASE(ipart)
@@ -1975,7 +1824,7 @@ contains
              istr = (mm-1)*nbins + in2b
              iend = (mm-1)*nbins + fn2b
           ELSE
-             STOP 'bulkMixrat: Invalid bin regime selection'
+             STOP 'bulkMixrat: Invalid aerosol bin regime selection'
           END IF
           mixrat(:,:,:) = SUM(a_maerop(:,:,:,istr:iend),DIM=4)
        CASE('cloud')
@@ -1985,6 +1834,8 @@ contains
           ELSE IF (itype == 'b') THEN
              istr = (mm-1)*ncld + icb%cur
              iend = (mm-1)*ncld + fcb%cur
+          ELSE
+             STOP 'bulkMixrat: Invalid cloud bin regime selection'
           END IF
           mixrat(:,:,:) = SUM(a_mcloudp(:,:,:,istr:iend),DIM=4)
        CASE('precp')
@@ -1998,6 +1849,8 @@ contains
           ELSE IF (itype == 'b') THEN
              istr = (mm-1)*nice + iib%cur
              iend = (mm-1)*nice + fib%cur
+          ELSE
+             STOP 'bulkMixrat: Invalid ice bin regime selection'
           END IF
           mixrat(:,:,:) = SUM(a_micep(:,:,:,istr:iend),DIM=4)
        CASE('snow')
@@ -2011,69 +1864,38 @@ contains
   ! ----------------------------------------------
   ! Subroutine binSpecMixrat: Calculate the mixing
   ! ratio of selected aerosol species in individual
-  ! bins. 
+  ! bins.
   !
   ! Juha Tonttila, FMI, 2015
   SUBROUTINE binSpecMixrat(ipart,icomp,ibin,mixr)
-    USE mo_submctl, ONLY : ncld, nbins, nprc,                  &
-                               in1a, in2a, in2b, fn1a, fn2a, fn2b, &
-                               ica, fca, icb, fcb, ira, fra,       &
-                               rhosu, rhooc, rhobc, rhodu, rhoss,  &
-                               rhonh, rhono, rhowa
-    USE class_componentIndex, ONLY : IsUsed, GetIndex
+    USE mo_submctl, ONLY : ncld, nbins, nprc, nice, nsnw
+    USE class_componentIndex, ONLY : GetIndex
 
     CHARACTER(len=*), INTENT(in) :: icomp  ! This should be either:
                                            ! SO4,OC,NO,NH,BC,DU,SS,H2O.
 
     CHARACTER(len=*), INTENT(in) :: ipart  ! This should be either:
-                                           ! aerosol,cloud,rain
+                                           ! aerosol,cloud,rain,ice,snow
     INTEGER, INTENT(in) :: ibin
 
     REAL, INTENT(out) :: mixr(nzp,nxp,nyp)
 
     INTEGER :: mm
-    REAL :: zrho
-
 
     ! Determine multipliers
-    ! zrho not needed anymore, should be removed
-    IF (icomp == 'SO4' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhosu
-    ELSE IF (icomp == 'OC' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhooc
-    ELSE IF (icomp == 'BC' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhobc
-    ELSE IF (icomp == 'DU' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhodu
-    ELSE IF (icomp == 'SS' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhoss
-    ELSE IF (icomp == 'NO' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhono
-    ELSE IF (icomp == 'NH' .AND. IsUsed(prtcl,icomp)) THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhonh
-    ELSE IF (icomp == 'H2O') THEN
-       mm = GetIndex(prtcl,icomp)
-       zrho = rhowa
-    ELSE
-       WRITE(*,*) 'bulkMixrat: invalid species ',icomp
-       STOP
-    END IF
+    mm = GetIndex(prtcl,icomp)
 
     SELECT CASE(ipart)
-
        CASE('aerosol')
           mixr(:,:,:) = a_maerop(:,:,:,(mm-1)*nbins+ibin)
        CASE('cloud')
           mixr(:,:,:) = a_mcloudp(:,:,:,(mm-1)*ncld+ibin)
        CASE('precp')
           mixr(:,:,:) = a_mprecpp(:,:,:,(mm-1)*nprc+ibin)
+       CASE('ice')
+          mixr(:,:,:) = a_micep(:,:,:,(mm-1)*nice+ibin)
+	   CASE('snow')
+          mixr(:,:,:) = a_msnowp(:,:,:,(mm-1)*nsnw+ibin)
     END SELECT
 
   END SUBROUTINE binSpecMixrat
@@ -2084,78 +1906,42 @@ contains
   ! Mass concentration for individual bins
   !
   ! Juha Tonttila, FMI, 2015
+  ! Tomi Raatikainen, FMI, 2016
   SUBROUTINE binMixrat(ipart,itype,ibin,ii,jj,kk,sumc)
-    USE mo_submctl, ONLY : ncld,nbins,nprc, nice, nsnw
+    USE mo_submctl, ONLY : ncld,nbins,nprc,nice,nsnw
     USE class_ComponentIndex, ONLY : GetNcomp
+    IMPLICIT NONE
 
     CHARACTER(len=*), INTENT(in) :: ipart
     CHARACTER(len=*), INTENT(in) :: itype
     INTEGER, INTENT(in) :: ibin,ii,jj,kk
     REAL, INTENT(out) :: sumc
 
-    INTEGER :: istr,iend
-    INTEGER :: s
-    INTEGER, ALLOCATABLE :: zidx(:)
-    LOGICAL, ALLOCATABLE :: zmask(:)
-    REAL, POINTER :: zdata(:)
+    INTEGER :: iend
 
-    istr = 0
-    iend = 0
-
-    istr=1
-    IF (itype == 'dry') iend=GetNcomp(prtcl) ! dry case
-    IF (itype == 'wet') iend=GetNcomp(prtcl)+1 ! wet case
-
-    ALLOCATE(zidx(GetNcomp(prtcl)+1))
+	! Number of components-1
+    IF (itype == 'dry') THEN
+		iend=GetNcomp(prtcl)-1 ! dry case
+    ELSEIF (itype == 'wet') THEN
+        iend=GetNcomp(prtcl) ! wet case
+    ELSE
+        STOP 'Error in binMixrat!'
+    ENDIF
 
     SELECT CASE(ipart)
        CASE('aerosol')
-          DO s = 1,GetNcomp(prtcl)+1
-             zidx(s) = (s-1)*nbins
-          END DO
-          ALLOCATE(zmask((GetNcomp(prtcl)+1)*nbins))
-          zdata => a_maerop(kk,ii,jj,:)
-
+          sumc = SUM( a_maerop(kk,ii,jj,ibin:iend*nbins+ibin:nbins) )
        CASE('cloud')
-          DO s = 1,GetNcomp(prtcl)+1
-             zidx(s) = (s-1)*ncld
-          END DO
-          ALLOCATE(zmask((GetNcomp(prtcl)+1)*ncld))
-          zdata => a_mcloudp(kk,ii,jj,:)
-
+          sumc = SUM( a_mcloudp(kk,ii,jj,ibin:iend*ncld+ibin:ncld) )
        CASE('precp')
-          DO s = 1,GetNcomp(prtcl)+1
-             zidx(s) = (s-1)*nprc
-          END DO
-          ALLOCATE(zmask((getNcomp(prtcl)+1)*nprc))
-          zdata => a_mprecpp(kk,ii,jj,:)
-
+          sumc = SUM( a_mprecpp(kk,ii,jj,ibin:iend*nprc+ibin:nprc) )
        CASE('ice')
-          DO s = 1,GetNcomp(prtcl)+1
-             zidx(s) = (s-1)*nice
-          END DO
-          ALLOCATE(zmask((GetNcomp(prtcl)+1)*nice))
-          zdata => a_micep(kk,ii,jj,:)
-
+          sumc = SUM( a_micep(kk,ii,jj,ibin:iend*nice+ibin:nice) )
        CASE('snow')
-          DO s = 1,GetNcomp(prtcl)+1
-             zidx(s) = (s-1)*nsnw
-          END DO
-          ALLOCATE(zmask((getNcomp(prtcl)+1)*nprc))
-          zdata => a_msnowp(kk,ii,jj,:)
-
+          sumc = SUM( a_msnowp(kk,ii,jj,ibin:iend*nsnw+ibin:nsnw) )
        CASE DEFAULT
           STOP 'bin mixrat error'
-
     END SELECT
-
-    zmask(:) = .FALSE.
-    zmask(zidx(istr:iend)+ibin) = .TRUE.
-    sumc = SUM( zdata(:),MASK=zmask(:) )
-
-    IF (ALLOCATED(zmask)) DEALLOCATE(zmask)
-    IF (ALLOCATED(zidx)) DEALLOCATE(zidx)
-    NULLIFY(zdata)
 
   END SUBROUTINE binMixrat
 
@@ -2167,27 +1953,27 @@ contains
   ! Juha Tonttila, FMI, 2015
   !
   SUBROUTINE bulkNumc(ipart,itype,numc)
-    USE mo_submctl, ONLY : ncld, nbins, nprc, nice, nsnw,     &
-                               ica,fca,icb,fcb,ira,fra, &
+    USE mo_submctl, ONLY : ica,fca,icb,fcb,ira,fra, &
                                iia,fia,iib,fib,isa,fsa, &
-                               in1a,in2a,in2b,fn1a,fn2a,fn2b
+                               in1a,in2b,fn2a,fn2b
 
     CHARACTER(len=*), INTENT(in) :: ipart
     CHARACTER(LEN=*), INTENT(in) :: itype
     REAL, INTENT(out) :: numc(nzp,nxp,nyp)
-    INTEGER :: istr,iend,kk
+    INTEGER :: istr,iend
 
     istr = 0
     iend = 0
 
     ! Outputs #/kg
+	! No concentration limits (nlim or prlim) for number
 
     SELECT CASE(ipart)
        CASE('aerosol')
-          IF (itype == 'a') THEN ! Soluble
+          IF (itype == 'a') THEN ! Note: 1a and 2a combined
              istr = in1a
              iend = fn2a
-          ELSE IF (itype == 'b') THEN ! Insoluble
+          ELSE IF (itype == 'b') THEN ! 2b
              istr = in2b
              iend = fn2b
           END IF
@@ -2218,9 +2004,6 @@ contains
           istr = isa
           iend = fsa
           numc(:,:,:) = SUM(a_nsnowp(:,:,:,istr:iend),DIM=4)
-
-       CASE DEFAULT
-          WRITE(*,*) 'aijaijaija bulknumc'
     END SELECT
 
   END SUBROUTINE bulkNumc
@@ -2236,7 +2019,7 @@ contains
                                nice,nsnw,                     &
                                ica,fca,icb,fcb,ira,fra,       &
                                iia,fia,iib,fib,isa,fsa,       &
-                               in1a,fn1a,in2a,fn2a,in2b,fn2b, &
+                               in1a,fn2a,in2b,fn2b, &
                                nlim,prlim
     IMPLICIT NONE
 
@@ -2245,10 +2028,8 @@ contains
     REAL, INTENT(out) :: rad(nzp,nxp,nyp)
 
     REAL :: zvar1(nzp,nxp,nyp)
-    LOGICAL :: Nlg1ae(nbins),Nlg1cl(ncld),Nlg1pr(nprc), &
-               Nlg1ic(nice), Nlg1sn(nsnw)
 
-    INTEGER :: i,j,k,istr,iend
+    INTEGER :: istr,iend
 
     rad = 0.
 
@@ -2258,7 +2039,7 @@ contains
     SELECT CASE(ipart)
     CASE('aerosol')
 
-       IF (itype == 'a') THEN
+       IF (itype == 'a') THEN ! Note: 1a and 2a combined
           istr = in1a
           iend = fn2a
        ELSE IF (itype == 'b') THEN
@@ -2303,14 +2084,14 @@ contains
           STOP 'meanRadius: Invalid bin regime selection (ice)'
        END IF
 
-       CALL getRadius(istr,iend,nice,a_nicep,zvar1,nlim,a_Riwet,rad)
+       CALL getRadius(istr,iend,nice,a_nicep,zvar1,prlim,a_Riwet,rad)
 
     CASE('snow')
 
        istr = isa
        iend = fsa
 
-       CALL getRadius(istr,iend,nsnw,a_nsnowp,zvar1,nlim,a_Rswet,rad)
+       CALL getRadius(istr,iend,nsnw,a_nsnowp,zvar1,prlim,a_Rswet,rad)
 
     END SELECT
 

--- a/src/src_LES/grid.f90
+++ b/src/src_LES/grid.f90
@@ -53,9 +53,9 @@ module grid
   real              :: distim = 300.0      ! dissipation timescale
 
   real              :: sst=283.   ! Surface temperature      added by Zubair Maalick
-  real	            :: W1 = 0.9   !Water content
-  real		    :: W2 = 0.9
-  real		    :: W3 = 0.9
+  real            :: W1 = 0.9   !Water content
+  real            :: W2 = 0.9
+  real            :: W3 = 0.9
 
 
 
@@ -688,13 +688,13 @@ contains
     ! Added for SALSA
     character(len=7), save :: salsa_sbase(salsa_nn) = (/ &
          'time   ','zt     ','zm     ','xt     ','xm     ','yt     ',  &  ! 1 
-         'ym     ','aea    ','aeb    ','cla    ','clb    ','prc    ',  &  ! 7		
-         'ica    ','icb    ','snw    ','u0     ','v0     ','dn0    ',  &  ! 13							
-         'u      ','v      ','w      ','t      ','p      ','q      ',  &  ! 19	
-         'l      ','r      ','f      ','i      ','s      ',	       &  ! 25		
+         'ym     ','aea    ','aeb    ','cla    ','clb    ','prc    ',  &  ! 7
+         'ica    ','icb    ','snw    ','u0     ','v0     ','dn0    ',  &  ! 13
+         'u      ','v      ','w      ','t      ','p      ','q      ',  &  ! 19
+         'l      ','r      ','f      ','i      ','s      ',         &  ! 25
          'S_RH   ','S_RHI  ','S_Nact ','S_Na   ','S_Naba ','S_Rwaa ',  &  ! 30
          'S_Rwaba','S_Nb   ','S_Nabb ','S_Rwab ','S_Rwabb','S_Nc   ',  &  ! 36
-         'S_Ncba ','S_Ncbb ','S_Rwca ','S_Rwcb ','S_Rwcba','S_Rwcbb',  &  ! 42	 		
+         'S_Ncba ','S_Ncbb ','S_Rwca ','S_Rwcb ','S_Rwcba','S_Rwcbb',  &  ! 42
          'S_Np   ','S_Npba ','S_Rwpa ','S_Rwpba','S_Nic  ','S_Niba ',  &  ! 48
          'S_Nibb ','S_Rwia ','S_Rwib ','S_Rwiba','S_Rwibb','S_Ns   ',  &  ! 54
          'S_Nsba ','S_Rwsa ','S_Rwsba','S_aSO4a','S_aNHa ','S_aNOa ',  &  ! 60
@@ -704,7 +704,7 @@ contains
          'S_cSO4b','S_cNHb ','S_cNOb ','S_cOCb ','S_cBCb ','S_cDUb ',  &  ! 84
          'S_cSSb ','S_iSO4a','S_iNHa ','S_iNOa ','S_iOCa ','S_iBCa ',  &  ! 90
          'S_iDUa ','S_iSSa ','S_iSO4b','S_iNHb ','S_iNOb ','S_iOCb ',  &  ! 96
-         'S_iBCb ','S_iDUb ','S_iSSb ' /)								
+         'S_iBCb ','S_iDUb ','S_iSSb ' /)
          ! total 104
 
     LOGICAL, SAVE :: salsabool(salsa_nn)
@@ -823,14 +823,12 @@ contains
     ELSE IF (level == 4 .AND. lbinanl) THEN
        call define_nc( ncid0, nrec0, nvar0, sanal, n1=nzp, n2=nxp-4, n3=nyp-4,  &
                        inae_a=fn2a, inae_b=fn2b-fn2a, incld_a=fca%cur,          &
-                       incld_b=fcb%cur-fca%cur, inprc=fra	                &
-                                		                                )
+                       incld_b=fcb%cur-fca%cur, inprc=fra )
     ELSE IF (level == 5 .AND. lbinanl) THEN
         call define_nc( ncid0, nrec0, nvar0, sanal, n1=nzp, n2=nxp-4, n3=nyp-4,  &
                         inae_a=fn2a,  inae_b =fn2b-fn2a, incld_a=fca%cur,        &
                         incld_b=fcb%cur-fca%cur, inprc=fra, inice_a=fia%cur,     &
-                        inice_b=fib%cur-fia%cur, insnw=fsa                       &
-							                         )
+                        inice_b=fib%cur-fia%cur, insnw=fsa )
     END IF
     if (myid == 0) print *,'   ...starting record: ', nrec0
 
@@ -870,7 +868,7 @@ contains
     integer :: iret, VarID, nn, n
     integer :: ibeg(4), icnt(4), i1, i2, j1, j2
     INTEGER :: ibegsd(5), icntaea(5), icntaeb(5), icntcla(5), icntclb(5), icntpra(5), & ! Juha: For sizedistribution variables
-	       icntica(5), icnticb(5), icntsna(5)
+           icntica(5), icnticb(5), icntsna(5)
     REAL :: zsum(nzp,nxp,nyp) ! Juha: Helper for computing bulk output diagnostics
     REAL :: zvar(nzp,nxp,nyp)
 
@@ -1894,7 +1892,7 @@ contains
           mixr(:,:,:) = a_mprecpp(:,:,:,(mm-1)*nprc+ibin)
        CASE('ice')
           mixr(:,:,:) = a_micep(:,:,:,(mm-1)*nice+ibin)
-	   CASE('snow')
+       CASE('snow')
           mixr(:,:,:) = a_msnowp(:,:,:,(mm-1)*nsnw+ibin)
     END SELECT
 
@@ -1919,9 +1917,9 @@ contains
 
     INTEGER :: iend
 
-	! Number of components-1
+    ! Number of components-1
     IF (itype == 'dry') THEN
-		iend=GetNcomp(prtcl)-1 ! dry case
+        iend=GetNcomp(prtcl)-1 ! dry case
     ELSEIF (itype == 'wet') THEN
         iend=GetNcomp(prtcl) ! wet case
     ELSE
@@ -1966,7 +1964,7 @@ contains
     iend = 0
 
     ! Outputs #/kg
-	! No concentration limits (nlim or prlim) for number
+    ! No concentration limits (nlim or prlim) for number
 
     SELECT CASE(ipart)
        CASE('aerosol')

--- a/src/src_LES/init.f90
+++ b/src/src_LES/init.f90
@@ -79,7 +79,7 @@ contains
        IF (level >= 4) THEN
 
           ! Not needed when using interst. acivation?
-		  CALL maskactiv(zactmask,nxp,nyp,nzp,nbins,1,prtcl,a_rh)
+          CALL maskactiv(zactmask,nxp,nyp,nzp,nbins,1,prtcl,a_rh)
 
           n4 = GetNcomp(prtcl) + 1 ! Aerosol compoenents + water
 
@@ -165,7 +165,6 @@ contains
 
     use defs, only : alvl, cpr, cp, p00, R
     use sgsm, only : tkeinit
-    use util, only : azero, atob
     use thrm, only : thermo, rslf
 
     implicit none
@@ -257,7 +256,7 @@ contains
        call random_pert(nzp,nxp,nyp,zt,a_rp,xran,k)
     end if
 
-    call azero(nxyzp,a_wp)
+    a_wp=0.
     if(isgstyp == 2) call tkeinit(nxyzp,a_qp)
     !
     ! initialize thermodynamic fields
@@ -273,9 +272,9 @@ contains
        CALL init_gas_tracers
     END IF
 
-    call atob(nxyzp,a_up,a_uc)
-    call atob(nxyzp,a_vp,a_vc)
-    call atob(nxyzp,a_wp,a_wc)
+    a_uc=a_up
+    a_vc=a_vp
+    a_wc=a_wp
 
     return
   end subroutine fldinit
@@ -715,7 +714,7 @@ contains
              a_gaerop(k,i,j,:)  = MAX( a_gaerop(k,i,j,:)  + dtlt*a_gaerot(k,i,j,:), 0. )
              a_rp(k,i,j) = a_rp(k,i,j) + dtlt*a_rt(k,i,j)
 
-			IF(level < 5) cycle
+            IF(level < 5) cycle
 
              a_nicep(k,i,j,:)   = MAX( a_nicep(k,i,j,:)   + dtlt*a_nicet(k,i,j,:), 0. )
              a_nsnowp(k,i,j,:)  = MAX( a_nsnowp(k,i,j,:)  + dtlt*a_nsnowt(k,i,j,:), 0. )
@@ -807,7 +806,7 @@ contains
 
     nc = GetIndex(prtcl,'H2O')
     str = (nc-1)*ncld+b
-	   
+
        DO j = 1,nyp
           DO i = 1,nxp
              DO k = 1,nzp
@@ -851,10 +850,10 @@ contains
 
                 IF (a_nicep(k,i,j,b)  > prlim) THEN
                    CALL binMixrat('ice','dry',b,i,j,k,zvol)
-					zvol = zvol/rhosu
+                    zvol = zvol/rhosu
                    a_Ridry(k,i,j,b) = 0.5*( zvol/(pi6*a_nicep(k,i,j,b)) )**(1./3.)
                    CALL binMixrat('ice','wet',b,i,j,k,zvol)
-					zvol = zvol/rhoic
+                    zvol = zvol/rhoic
                    a_Riwet(k,i,j,b) = 0.5*( zvol/(pi6*a_nicep(k,i,j,b)) )**(1./3.)
                 ELSE
                    a_Ridry(k,i,j,b) = 1.e-10
@@ -1156,15 +1155,15 @@ contains
     INTEGER :: i,j,k,bb,m
     REAL :: zumA, zumB, zumCumIce, zumCumLiq, &
             excessIce, excessLiq,excessFracIce,excessFracLiq
-	
-	! initialize liquid and ice only if it is determinded so in the namelist.salsa
-	IF(initliqice) THEN
-    	IF(level==4) THEN
-    	    iceFracA = 0.0; iceFracB = 0.0;
-    	END IF
+
+    ! initialize liquid and ice only if it is determinded so in the namelist.salsa
+    IF(initliqice) THEN
+        IF(level==4) THEN
+            iceFracA = 0.0; iceFracB = 0.0;
+        END IF
         !#cloudinit
-    	DO k = 2,nzp  ! DONT PUT STUFF INSIDE THE GROUND
-       	   DO j = 1,nyp
+        DO k = 2,nzp  ! DONT PUT STUFF INSIDE THE GROUND
+           DO j = 1,nyp
               DO i = 1,nxp
                  IF (a_rh(k,i,j)<1.0  .or. a_scr1(k,i,j) > 273.15) CYCLE
                  zumA=sum(a_naerop(k,i,j,in2a:fn2a))
@@ -1173,12 +1172,12 @@ contains
                  zumCumIce = 0.0
                  zumCumLiq = 0.0
                  excessIce = 0.0
-             	 excessFracIce = 1.0
-             	 excessFracLiq = 1.0
+                 excessFracIce = 1.0
+                 excessFracLiq = 1.0
 
-             	 DO bb=fn2a,in2a,-1
+                 DO bb=fn2a,in2a,-1
 
-               	 	IF(a_scr1(k,i,j) < 273.15 .and. zumCumIce<iceFracA*zumA .and. a_naerop(k,i,j,bb)>10e-10) THEN !initialize ice if it is cold enough
+                    IF(a_scr1(k,i,j) < 273.15 .and. zumCumIce<iceFracA*zumA .and. a_naerop(k,i,j,bb)>10e-10) THEN !initialize ice if it is cold enough
 
                        excessIce =min(abs(zumCumIce-iceFracA*zumA),a_naerop(k,i,j,bb))
                        a_nicep(k,i,j,bb-3) = a_nicep(k,i,j,bb-3) + excessIce
@@ -1402,7 +1401,7 @@ END SUBROUTINE liq_ice_init
        ! The true number of altitude levels
        nc_levs=i-1
     END IF
-	!
+    !
     IF (zlevs(nc_levs)<zt(nzp)) then
        if (myid == 0) print *, '  ABORTING: Model top above aerosol sounding top'
        if (myid == 0) print '(2F12.2)', zlevs(nc_levs), zt(nzp)

--- a/src/src_LES/mcrp.f90
+++ b/src/src_LES/mcrp.f90
@@ -22,7 +22,7 @@ module mcrp
   use defs, only : alvl, alvi, rowt, pi, Rm, cp, kb, g, vonk
   use grid, only : dtlt, dzt, nxp, nyp, nzp,a_pexnr, a_rp, a_tp, th00, CCN,     &
        dn0, pi0, a_rt, a_tt, a_rpp, a_rpt, a_npp, a_npt, a_rv, a_rc, a_theta,   &
-       a_press, a_scr1, a_scr2, precip, a_dn, a_rhop, a_ustar,                  &
+       a_press, a_scr1, a_scr2, precip, a_dn, a_ustar,                  &
        a_Radry, a_Rawet, a_Rcdry, a_Rcwet, a_Rpdry, a_Rpwet,                    &
        a_Riwet, a_Rswet,                                                        &
        a_naerop,  a_naerot,  a_maerop,  a_maerot,                               &
@@ -92,7 +92,7 @@ contains
                         a_nprecpp, a_nprecpt, a_mprecpp, a_mprecpt,          &
                         a_nicep,   a_nicet,   a_micep,   a_micet,            &
                         a_nsnowp,  a_nsnowt,  a_msnowp,  a_msnowt,           &
-                        a_rhop, a_ustar, precip, snowin, a_tt                )
+                        a_ustar, precip, snowin, a_tt                )
     end select
 
   end subroutine micro
@@ -520,12 +520,11 @@ contains
                          nprecpp,nprecpt,mprecpp,mprecpt,  &
                          nicep,  nicet,  micep,  micet,    &
                          nsnowp, nsnowt, msnowp, msnowt,   &
-                         rhop,ustar,rrate, srate, tlt          )
+                         ustar,rrate, srate, tlt          )
 
     USE mo_submctl, ONLY : nbins, ncld, nprc,           &
                                nice,  nsnw,                 &
-                               ica,fcb,ira,fra,nlim,prlim,  &
-                               iia,fib,isa,fsa,             &
+                               nlim,prlim,  &
                                rhowa,rhoic
     USE class_ComponentIndex, ONLY : GetIndex, GetNcomp
     IMPLICIT NONE
@@ -542,7 +541,6 @@ contains
                         Riwet(n1,n2,n3,nice),     &
                         Rswet(n1,n2,n3,nsnw),     &
 
-                        rhop(n1,n2,n3,nbins),     &
                         ustar(n2,n3),             &
 
                         naerop(n1,n2,n3,nbins),   &
@@ -570,8 +568,8 @@ contains
                            rrate(n1,n2,n3),           &
                            srate(n1,n2,n3)              ! snowing rate
 
-    INTEGER :: bin, ss,bs, kp1
-    INTEGER :: i,j,k,nc,istr,iend,ni
+    INTEGER :: ss, kp1
+    INTEGER :: i,j,k,nc,istr,iend
     REAL :: xnpts
     REAL :: v1(n1)
 
@@ -621,11 +619,11 @@ contains
     !-------------------------------------------------------
     IF (sed_aero) THEN
 
-       andiv = NumDivergence(n1,n2,n3,nbins,tk,a_dn,1500.,Rawet,naerop,dzt)
-       amdiv = MassDivergence(n1,n2,n3,n4,nbins,tk,a_dn,1500.,Rawet,naerop,maerop,dzt)
+       andiv = NumDivergence(n1,n2,n3,nbins,tk,a_dn,1500.,Rawet,naerop,dzt,nlim)
+       amdiv = MassDivergence(n1,n2,n3,n4,nbins,tk,a_dn,1500.,Rawet,naerop,maerop,dzt,nlim)
        
-       andep = NumDepositionSlow(n1,n2,n3,nbins,a_dn,1500.,tk,ustar,naerop,Rawet)
-       amdep = MassDepositionSlow(n1,n2,n3,n4,nbins,a_dn,1500.,tk,ustar,naerop,maerop,Rawet)
+       andep = NumDepositionSlow(n1,n2,n3,nbins,a_dn,1500.,tk,ustar,naerop,Rawet,nlim)
+       amdep = MassDepositionSlow(n1,n2,n3,n4,nbins,a_dn,1500.,tk,ustar,naerop,maerop,Rawet,nlim)
        
        naerot = naerot - andiv
        naerot(2,:,:,:) = naerot(2,:,:,:) - andep
@@ -650,11 +648,11 @@ contains
 
     IF (sed_cloud) THEN
 
-       cndiv = NumDivergence(n1,n2,n3,ncld,tk,a_dn,rhowa,Rcwet,ncloudp,dzt)
-       cmdiv = MassDivergence(n1,n2,n3,n4,ncld,tk,a_dn,rhowa,Rcwet,ncloudp,mcloudp,dzt)
+       cndiv = NumDivergence(n1,n2,n3,ncld,tk,a_dn,rhowa,Rcwet,ncloudp,dzt,nlim)
+       cmdiv = MassDivergence(n1,n2,n3,n4,ncld,tk,a_dn,rhowa,Rcwet,ncloudp,mcloudp,dzt,nlim)
     
-       cndep = NumDepositionSlow(n1,n2,n3,ncld,a_dn,rhowa,tk,ustar,ncloudp,Rcwet)
-       cmdep = MassDepositionSlow(n1,n2,n3,n4,ncld,a_dn,rhowa,tk,ustar,ncloudp,mcloudp,Rcwet)
+       cndep = NumDepositionSlow(n1,n2,n3,ncld,a_dn,rhowa,tk,ustar,ncloudp,Rcwet,nlim)
+       cmdep = MassDepositionSlow(n1,n2,n3,n4,ncld,a_dn,rhowa,tk,ustar,ncloudp,mcloudp,Rcwet,nlim)
 
        ncloudt = ncloudt - cndiv
        ncloudt(2,:,:,:) = ncloudt(2,:,:,:) - cndep
@@ -679,12 +677,11 @@ contains
 
     IF (sed_ice) THEN
 
-       ! JÄÄN TIHEYS?
-       indiv = NumDivergence(n1,n2,n3,nice,tk,a_dn,rhoic,Riwet,nicep,dzt)
-       imdiv = MassDivergence(n1,n2,n3,n4,nice,tk,a_dn,rhoic,Riwet,nicep,micep,dzt)
+       indiv = NumDivergence(n1,n2,n3,nice,tk,a_dn,rhoic,Riwet,nicep,dzt,prlim)
+       imdiv = MassDivergence(n1,n2,n3,n4,nice,tk,a_dn,rhoic,Riwet,nicep,micep,dzt,prlim)
 
-       indep = NumDepositionSlow(n1,n2,n3,nice,a_dn,rhoic,tk,ustar,nicep,Riwet)
-       imdep = MassDepositionSlow(n1,n2,n3,n4,nice,a_dn,rhoic,tk,ustar,nicep,micep,Riwet)
+       indep = NumDepositionSlow(n1,n2,n3,nice,a_dn,rhoic,tk,ustar,nicep,Riwet,prlim)
+       imdep = MassDepositionSlow(n1,n2,n3,n4,nice,a_dn,rhoic,tk,ustar,nicep,micep,Riwet,prlim)
 
        nicet = nicet - indiv 
        nicet(2,:,:,:) = nicet(2,:,:,:) - indep
@@ -711,7 +708,7 @@ contains
     ! ---------------------------------------------------------
     ! SEDIMENTATION/DEPOSITION OF FAST PRECIPITATING PARTICLES
     IF (sed_precp) THEN
-       CALL DepositionFast(n1,n2,n3,n4,nprc,tk,a_dn,rowt,Rpwet,nprecpp,mprecpp,tstep,dzt,prnt,prvt,remprc)
+       CALL DepositionFast(n1,n2,n3,n4,nprc,tk,a_dn,rowt,Rpwet,nprecpp,mprecpp,tstep,dzt,prnt,prvt,remprc,prlim)
        
        ! Rain rate
        nc = GetIndex(prtcl,'H2O')
@@ -725,7 +722,6 @@ contains
                 mprecpt(k,i,j,:) = mprecpt(k,i,j,:) + prvt(k,i,j,:)/tstep
 
                 kp1 = k + 1
-                !          
                 rrate(k,i,j) = -SUM(prvt(k,i,j,istr:iend)*2.) * alvl*0.5*(a_dn(k,i,j)+a_dn(kp1,i,j))
                 
                 IF (sflg) v1(k) = v1(k) + rrate(k,i,j)*xnpts
@@ -735,12 +731,12 @@ contains
     END IF
     
     IF (sed_snow) THEN
-       CALL DepositionFast(n1,n2,n3,n4,nsnw,tk,a_dn,rowt,Rswet,nsnowp,msnowp,tstep,dzt,srnt,srvt,remsnw)
+       CALL DepositionFast(n1,n2,n3,n4,nsnw,tk,a_dn,rowt,Rswet,nsnowp,msnowp,tstep,dzt,srnt,srvt,remsnw,prlim)
            
        ! Snow rate
        nc = GetIndex(prtcl,'H2O')
-       istr = (nc-1)*nprc + 1
-       iend = nc*nprc
+       istr = (nc-1)*nsnw + 1
+       iend = nc*nsnw
        DO j = 3,n3-2
           DO i = 3,n2-2
              DO k = n1-2,2,-1
@@ -749,7 +745,6 @@ contains
                 msnowt(k,i,j,:) = msnowt(k,i,j,:) + srvt(k,i,j,:)/tstep
 
                 kp1 = k + 1
-                !                            
                 srate(k,i,j) = -SUM(srvt(k,i,j,istr:iend)*1.) * alvi*0.5*(a_dn(k,i,j)+a_dn(kp1,i,j)) 
                 
                 IF (sflg) v1(k) = v1(k) + srate(k,i,j)*xnpts
@@ -783,8 +778,7 @@ contains
 
   ! -----------------------------------------------------------------
 
-  FUNCTION NumDivergence(n1,n2,n3,nn,tk,adn,pdn,rwet,numc,dzt) RESULT(flxdiv)
-    USE mo_submctl, ONLY : nlim, prlim
+  FUNCTION NumDivergence(n1,n2,n3,nn,tk,adn,pdn,rwet,numc,dzt,clim) RESULT(flxdiv)
     IMPLICIT NONE
 
     INTEGER, INTENT(in) :: n1,n2,n3       ! Grid numbers
@@ -795,6 +789,7 @@ contains
     REAL, INTENT(in) :: rwet(n1,n2,n3,nn) ! Particle wet radius
     REAL, INTENT(in) :: numc(n1,n2,n3,nn) ! Particle number concentrations
     REAL, INTENT(in) :: dzt(n1)           ! Inverse of grid level thickness
+    REAL, INTENT(IN) :: clim                ! Concentration limit
 
     INTEGER :: i,j,k,kp1
     INTEGER :: bin
@@ -805,13 +800,12 @@ contains
     real, parameter :: B = 0.42
     real, parameter :: C = 0.87
 
-    REAL :: avis(n1), kvis(n1)           ! Viscosity of air, kinematic viscosity
-    REAL :: lambda(n1)                   ! Mean free path
-    REAL :: va                           ! Thermal speed of air molecule
-    REAL :: Kn, GG                       ! Knudsen number, slip correction
-    REAL :: vc                           ! Critical fall speedd
-
-    REAL :: rhoref                       ! Reference air density in STP conditions
+    REAL :: avis, kvis           ! Viscosity of air, kinematic viscosity
+    REAL :: lambda              ! Mean free path
+    REAL :: va                    ! Thermal speed of air molecule
+    REAL :: Kn, GG               ! Knudsen number, slip correction
+    REAL :: vc                    ! Critical fall speed
+    REAL :: rhoref               ! Reference air density in STP conditions
 
     REAL :: rfl(n1,nn)
     REAL :: flxdiv(n1,n2,n3,nn)
@@ -825,44 +819,34 @@ contains
        DO i = 3,n2-2
 
           rfl = 0.
-          avis = 0.; kvis = 0.; lambda = 0.
 
           DO k=n1-1,2,-1
              kp1 = k+1
 
              ! atm modelling Eq.4.54
-             avis(k)=1.8325e-5*(416.16/(tk(k,i,j)+120.0))*(tk(k,i,j)/296.16)**1.5
-             kvis(k) =  avis(k)/adn(k,i,j) !actual density ???
+             avis=1.8325e-5*(416.16/(tk(k,i,j)+120.0))*(tk(k,i,j)/296.16)**1.5
+             kvis =  avis/adn(k,i,j) !actual density ???
              va = sqrt(8*kb*tk(k,i,j)/(pi*M)) ! thermal speed of air molecule
-             lambda(k) = 2*avis(k)/(adn(k,i,j)*va) !mean free path
+             lambda = 2*avis/(adn(k,i,j)*va) !mean free path
 
              ! Fluxes
              !------------------
              ! -- Calculate the *corrections* for small particles
              DO bin = 1,nn
-                   
-                Kn = lambda(k)/rwet(k,i,j,bin)
-                GG = 1+ Kn*(A+B*exp(-C/Kn))
+                IF (numc(k,i,j,bin)<clim) CYCLE
 
-                IF (numc(k,i,j,bin)*adn(k,i,j) > prlim) THEN
-                   IF ( rwet(k,i,j,bin) < 20.e-6 ) THEN
-                      vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g /  &
-                           (9.*avis(k)))*GG
-                      vc = MIN(vc,1.)
-                   ELSE IF (rwet(k,i,j,bin) >= 20.e-6) THEN
-                      vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
-                      vc = MIN(vc,5.) 
-                   END IF
+                IF (rwet(k,i,j,bin) < 20.e-6 ) THEN
+                   Kn = lambda/rwet(k,i,j,bin)
+                   GG = 1.+ Kn*(A+B*exp(-C/Kn))
+                   vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g/(9.*avis))*GG
+                   vc = MIN(vc,1.)
                 ELSE
-                   vc = 1.e-10
+                   vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
+                   vc = MIN(vc,5.) 
                 END IF
 
                 ! Flux for the particle number
-                IF ( k > 2 ) THEN
-                   rfl(k,bin) = -numc(k,i,j,bin)*vc
-                ELSE
-                   rfl(k,bin) = 0.
-                END IF
+                IF ( k > 2 ) rfl(k,bin) = -numc(k,i,j,bin)*vc
 
              END DO
 
@@ -878,8 +862,7 @@ contains
   
   ! ----------------------------------------------------
 
-  FUNCTION MassDivergence(n1,n2,n3,n4,nn,tk,adn,pdn,rwet,numc,mass,dzt) RESULT(flxdiv)
-    USE mo_submctl, ONLY : nlim,prlim
+  FUNCTION MassDivergence(n1,n2,n3,n4,nn,tk,adn,pdn,rwet,numc,mass,dzt,clim) RESULT(flxdiv)
     IMPLICIT NONE
 
     INTEGER, INTENT(in) :: n1,n2,n3,n4       ! Grid numbers, number of chemical species
@@ -891,6 +874,7 @@ contains
     REAL, INTENT(in) :: numc(n1,n2,n3,nn)    ! Particle number concentration
     REAL, INTENT(in) :: mass(n1,n2,n3,nn*n4) ! Particle mass mixing ratio
     REAL, INTENT(in) :: dzt(n1)              ! Inverse of grid level thickness
+    REAL, INTENT(IN) :: clim                ! Concentration limit
 
     INTEGER :: i,j,k,kp1
     INTEGER :: bin,ss,bs
@@ -901,13 +885,12 @@ contains
     real, parameter :: B = 0.42
     real, parameter :: C = 0.87
 
-    REAL :: avis(n1), kvis(n1)           ! Viscosity of air, kinematic viscosity
-    REAL :: lambda(n1)                   ! Mean free path
-    REAL :: va                           ! Thermal speed of air molecule
-    REAL :: Kn, GG                       ! Knudsen number, slip correction
-    REAL :: vc                           ! Critical fall speedd
-
-    REAL :: rhoref                       ! Reference air density in STP conditions
+    REAL :: avis, kvis           ! Viscosity of air, kinematic viscosity
+    REAL :: lambda              ! Mean free path
+    REAL :: va                    ! Thermal speed of air molecule
+    REAL :: Kn, GG               ! Knudsen number, slip correction
+    REAL :: vc                    ! Critical fall speed
+    REAL :: rhoref               ! Reference air density in STP conditions
 
     REAL :: rfl(n1,nn,n4)
     REAL :: flxdiv(n1,n2,n3,nn*n4)
@@ -921,37 +904,30 @@ contains
        DO i = 3,n2-2
 
           rfl = 0.
-          avis = 0.; kvis = 0.; lambda = 0.
-
+          
           DO k=n1-1,2,-1
              kp1 = k+1
 
              ! atm modelling Eq.4.54
-             avis(k)=1.8325e-5*(416.16/(tk(k,i,j)+120.0))*(tk(k,i,j)/296.16)**1.5
-             kvis(k) =  avis(k)/adn(k,i,j) !actual density ???
+             avis=1.8325e-5*(416.16/(tk(k,i,j)+120.0))*(tk(k,i,j)/296.16)**1.5
+             kvis =  avis/adn(k,i,j) !actual density ???
              va = sqrt(8*kb*tk(k,i,j)/(pi*M)) ! thermal speed of air molecule
-             lambda(k) = 2*avis(k)/(adn(k,i,j)*va) !mean free path
+             lambda = 2*avis/(adn(k,i,j)*va) !mean free path
 
              ! Fluxes
              !------------------
              ! -- Calculate the *corrections* for small particles
              DO bin = 1,nn
-                
-                Kn = lambda(k)/rwet(k,i,j,bin)
-                GG = 1+ Kn*(A+B*exp(-C/Kn))
-                IF (numc(k,i,j,bin)*adn(k,i,j) > prlim) THEN
-
-                   IF (rwet(k,i,j,bin) < 20.e-6) THEN
-                      vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g /  &
-                           (9.*avis(k)))*GG
-                      vc = MIN(vc,1.)
-                   ELSE IF (rwet(k,i,j,bin) >= 20.e-6) THEN
-                      vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
-                      vc = MIN(vc,5.) 
-                   END IF
-
+                IF (numc(k,i,j,bin)<clim) CYCLE
+        
+                IF (rwet(k,i,j,bin) < 20.e-6 ) THEN
+                   Kn = lambda/rwet(k,i,j,bin)
+                   GG = 1.+ Kn*(A+B*exp(-C/Kn))
+                   vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g/(9.*avis))*GG
+                   vc = MIN(vc,1.)
                 ELSE
-                   vc = 1.e-10
+                   vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
+                   vc = MIN(vc,5.) 
                 END IF
 
                 ! Flux for the particle mass
@@ -981,8 +957,7 @@ contains
 
   ! ------------------------------------------
 
-  FUNCTION NumDepositionSlow(n1,n2,n3,nn,adn,pdn,tk,ustar,numc,rwet) RESULT(depflx)
-    USE mo_submctl, ONLY : nlim, prlim
+  FUNCTION NumDepositionSlow(n1,n2,n3,nn,adn,pdn,tk,ustar,numc,rwet,clim) RESULT(depflx)
     IMPLICIT NONE
 
     INTEGER, INTENT(in) :: n1,n2,n3,nn
@@ -992,6 +967,7 @@ contains
     REAL, INTENT(in) :: ustar(n2,n3)
     REAL, INTENT(in) :: numc(n1,n2,n3,nn)
     REAL, INTENT(in) :: rwet(n1,n2,n3,nn)
+    REAL, INTENT(IN) :: clim                ! Concentration limit
 
     INTEGER :: i,j,k,bin
 
@@ -1001,7 +977,6 @@ contains
     real, parameter :: M = 4.8096e-26 ! average mass of one air molecule, eq2.3 fundamentals of atm.
                                       ! modelling [kg molec-1]
 
-    REAL :: Cc          ! Cunningham correction factor
     REAL :: GG
     REAL :: St, Sc, Kn
     REAL :: lambda      ! Mean free path
@@ -1009,14 +984,12 @@ contains
     REAL :: avis,kvis   ! Air viscosity, kinematic viscosity
     REAL :: va          ! Thermal speed of air molecule
     REAL :: vc,vd       ! Particle fall speed, deposition velocity
-    REAL :: ra,rb,rt
-
+    REAL :: rt
     REAL :: rhoref      ! Reference air density in STP conditions
 
     REAL :: rfl(nn)
 
     REAL :: depflx(n2,n3,nn)
-
 
     depflx = 0.
 
@@ -1038,42 +1011,28 @@ contains
           rfl = 0.
 
           DO bin = 1,nn
+             IF (numc(k,i,j,bin) < clim) CYCLE
 
              Kn = lambda/rwet(k,i,j,bin)
-             GG = 1+ Kn*(A+B*exp(-C/Kn))
-             IF (numc(k,i,j,bin)*adn(k,i,j) > prlim) THEN
+             GG = 1.+ Kn*(A+B*exp(-C/Kn))
 
-                IF (rwet(k,i,j,bin) < 20.e-6) THEN
-                   vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g /  &
-                        (9.*avis))*GG
-                   vc = MIN(vc,1.)
-                ELSE IF (rwet(k,i,j,bin) >= 20.e-6) THEN
-                   vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
-                   vc = MIN(vc,5.) 
-                END IF
-
+             IF (rwet(k,i,j,bin) < 20.e-6 ) THEN
+                vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g/(9.*avis))*GG
+				vc = MIN(vc,1.)
              ELSE
-                vc = 1.e-10
+                vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
+                vc = MIN(vc,5.) 
              END IF
-
-             ! Resistance Rb for dry deposition
-             ! Cunningham correction factor atm chem&phy eq19.20
-             Cc = 1.0 + (lambda/rwet(k,i,j,bin)) *  &
-                  (1.257 + 0.4*EXP(-0.55*rwet(k,i,j,bin)*2.0/lambda))
+             
              ! Particle diffusitivity  (15.29) in jacobson book
-             mdiff = (kb*tk(k,i,j)*Cc)/(6.0*pi*avis*rwet(k,i,j,bin))
+             mdiff = (kb*tk(k,i,j)*GG)/(6.0*pi*avis*rwet(k,i,j,bin))
              
              Sc = kvis/mdiff
              St = vc*ustar(i,j)**2.0/g*kvis
              if (St<0.01) St=0.01
-             rb = 1.0/MAX(epsilon(1.0),(ustar(i,j)*(Sc**(-2.0/3.0)+10**(-3.0/St)))) ! atm chem&phy eq19.18  !SAMI
+             rt = 1.0/MAX(epsilon(1.0),(ustar(i,j)*(Sc**(-2.0/3.0)+10**(-3.0/St)))) ! atm chem&phy eq19.18
 
-             rt = rb !+ ra
-             IF (numc(k,i,j,bin) > nlim) THEN
-                vd = (1./rt) + vc
-             ELSE
-                vd = 1.e-10
-             END IF
+             vd = (1./rt) + vc
 
              rfl(bin) = -numc(k,i,j,bin)*vd
 
@@ -1089,8 +1048,7 @@ contains
 
   ! ------------------------------------------
 
-  FUNCTION MassDepositionSlow(n1,n2,n3,n4,nn,adn,pdn,tk,ustar,numc,mass,rwet) RESULT(depflx)
-    USE mo_submctl, ONLY : prlim
+  FUNCTION MassDepositionSlow(n1,n2,n3,n4,nn,adn,pdn,tk,ustar,numc,mass,rwet,clim) RESULT(depflx)
     IMPLICIT NONE
 
     INTEGER, INTENT(in) :: n1,n2,n3,n4,nn
@@ -1101,6 +1059,7 @@ contains
     REAL, INTENT(in) :: numc(n1,n2,n3,nn)
     REAL, INTENT(in) :: mass(n1,n2,n3,nn*n4)
     REAL, INTENT(in) :: rwet(n1,n2,n3,nn)
+    REAL, INTENT(IN) :: clim                ! Concentration limit
 
     INTEGER :: i,j,k,bin
     INTEGER :: ss,bs
@@ -1111,7 +1070,6 @@ contains
     real, parameter :: M = 4.8096e-26 ! average mass of one air molecule, eq2.3 fundamentals of atm.
                                       ! modelling [kg molec-1]
 
-    REAL :: Cc          ! Cunningham correction factor
     REAL :: GG
     REAL :: St, Sc, Kn
     REAL :: lambda      ! Mean free path
@@ -1119,14 +1077,12 @@ contains
     REAL :: avis,kvis   ! Air viscosity, kinematic viscosity
     REAL :: va          ! Thermal speed of air molecule
     REAL :: vc,vd       ! Particle fall speed, deposition velocity
-    REAL :: ra,rb,rt
-
-    REAL :: rfl(nn,n4)
-    
+    REAL :: rt
     REAL :: rhoref      ! Reference air density in STP conditions
 
-    REAL :: depflx(n2,n3,nn*n4)
+    REAL :: rfl(nn,n4)
 
+    REAL :: depflx(n2,n3,nn*n4)
 
     depflx = 0.
 
@@ -1148,43 +1104,29 @@ contains
           rfl = 0.
 
           DO bin = 1,nn
+             IF (numc(k,i,j,bin) < clim) CYCLE
 
              Kn = lambda/rwet(k,i,j,bin)
-             GG = 1+ Kn*(A+B*exp(-C/Kn))
-             IF (numc(k,i,j,bin)*adn(k,i,j) > prlim) THEN
-                
-                IF (rwet(k,i,j,bin) < 20.e-6) THEN
-                   vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g /  &
-                        (9.*avis))*GG
-                   vc = MIN(vc,1.)
-                ELSE IF (rwet(k,i,j,bin) >= 20.e-6) THEN
-                   vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
-                   vc = MIN(vc,5.) 
-                END IF
+             GG = 1.+ Kn*(A+B*exp(-C/Kn))
 
+             IF (rwet(k,i,j,bin) < 20.e-6 ) THEN
+                vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g/(9.*avis))*GG
+                vc = MIN(vc,1.)
              ELSE
-                vc = 1.e-10
+                vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
+                vc = MIN(vc,5.) 
              END IF
 
-             ! Resistance Rb for dry deposition
-             ! Cunningham correction factor atm chem&phy eq19.20
-             Cc = 1.0 + (lambda/rwet(k,i,j,bin)) *  &
-                  (1.257 + 0.4*EXP(-0.55*rwet(k,i,j,bin)*2.0/lambda))
              ! Particle diffusitivity  (15.29) in jacobson book
-             mdiff = (kb*tk(k,i,j)*Cc)/(6.0*pi*avis*rwet(k,i,j,bin))
+             mdiff = (kb*tk(k,i,j)*GG)/(6.0*pi*avis*rwet(k,i,j,bin))
              
              Sc = kvis/mdiff
              St = vc*ustar(i,j)**2.0/g*kvis
              if (St<0.01) St=0.01
-             rb = 1.0/MAX(epsilon(1.0),(ustar(i,j)*(Sc**(-2.0/3.0)+10**(-3.0/St)))) ! atm chem&phy eq19.18 !SAMI
+             rt = 1.0/MAX(epsilon(1.0),(ustar(i,j)*(Sc**(-2.0/3.0)+10**(-3.0/St)))) ! atm chem&phy eq19.18
 
-             rt = rb !+ ra
-             IF (numc(k,i,j,bin) > prlim) THEN
-                vd = (1./rt) + vc
-             ELSE
-                vd = 1.e-10
-             END IF
-
+             vd = (1./rt) + vc
+    
              DO ss = 1,n4
                 bs = (ss-1)*nn + bin
                 rfl(bin,ss) = -mass(k,i,j,bs)*vd
@@ -1201,7 +1143,7 @@ contains
   END FUNCTION MassDepositionSlow
   
   !------------------------------------------------------------------
-  SUBROUTINE DepositionFast(n1,n2,n3,n4,nn,tk,adn,pdn,rwet,numc,mass,tstep,dzt,prnt,prvt,remprc)
+  SUBROUTINE DepositionFast(n1,n2,n3,n4,nn,tk,adn,pdn,rwet,numc,mass,tstep,dzt,prnt,prvt,remprc,clim)
     IMPLICIT NONE
 
     INTEGER, INTENT(in) :: n1,n2,n3,n4,nn
@@ -1213,11 +1155,12 @@ contains
     REAL, INTENT(in) :: mass(n1,n2,n3,nn*n4)
     REAL, INTENT(in) :: tstep
     REAL, INTENT(in) :: dzt(n1)
+    REAL, INTENT(IN) :: clim                ! Concentration limit
 
     REAL, INTENT(out) :: prnt(n1,n2,n3,nn), prvt(n1,n2,n3,nn*n4)     ! Number and mass tendencies due to fallout
     REAL, INTENT(out) :: remprc(n2,n3,nn*n4)
 
-    INTEGER :: k,i,j,bin,bs
+    INTEGER :: k,i,j,bin
     INTEGER :: istr,iend
 
     real, parameter :: A = 1.249 ! fundamentals of atm. modelling pg509
@@ -1226,14 +1169,13 @@ contains
     real, parameter :: M = 4.8096e-26 ! average mass of one air molecule, eq2.3 fundamentals of atm.
                                       ! modelling [kg molec-1]
 
-    REAL :: Cc          ! Cunningham correction factor
     REAL :: GG
-    REAL :: St, Sc, Kn
+    REAL :: Kn
     REAL :: lambda      ! Mean free path
-    REAL :: mdiff       ! Particle diffusivity
     REAL :: avis,kvis   ! Air viscosity, kinematic viscosity
     REAL :: va          ! Thermal speed of air molecule
     REAL :: vc
+    REAL :: rhoref      ! Reference air density in STP conditions
 
     ! For precipitation:
     REAL :: fd,fdmax,fdos ! Fall distance for rain drops, max fall distance, overshoot from nearest grid level
@@ -1243,14 +1185,12 @@ contains
     REAL :: prdepn(nn), prdepv(nn,n4)
     INTEGER :: kf, ni,fi
     LOGICAL :: prcdep  ! Deposition flag
-    REAL :: rhoref     ! Reference air density in STP conditions
-
-
-    rhoref = 1.01325e5/(287.*273.15)
 
     remprc(:,:,:) = 0.
     prnt(:,:,:,:) = 0.
     prvt(:,:,:,:) = 0.
+
+    rhoref = 1.01325e5/(287.*273.15)
 
     DO j = 3,n3-2
        
@@ -1274,21 +1214,18 @@ contains
 
              ! Precipitation bin loop
              DO bin = 1,nn
-             
-                fdmax = 0.
+                IF (numc(k,i,j,bin) < clim) CYCLE
              
                 ! Terminal velocity
-                Kn = lambda/rwet(k,i,j,bin)
-                GG = 1. + Kn*(A+B*exp(-C/Kn))
-                IF (rwet(k,i,j,bin) < 20.e-6) THEN
-                   vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g / &
-                        (9.*avis))
-                ELSE IF (rwet(k,i,j,bin) >= 20.e-6) THEN
+                IF (rwet(k,i,j,bin) < 20.e-6 ) THEN
+                   Kn = lambda/rwet(k,i,j,bin)
+                   GG = 1.+ Kn*(A+B*exp(-C/Kn))
+                   vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g/(9.*avis))*GG
+                ELSE
                    vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
                 END IF
-
                 vc = MIN(vc,10.)
-             
+
                 ! Determine output flux for current level: Find the closest level to which the
                 ! current drop parcel can fall within 1 timestep. If the lowest atmospheric level
                 ! is reached, the drops are sedimented.

--- a/src/src_LES/mcrp.f90
+++ b/src/src_LES/mcrp.f90
@@ -27,10 +27,10 @@ module mcrp
        a_Riwet, a_Rswet,                                                        &
        a_naerop,  a_naerot,  a_maerop,  a_maerot,                               &
        a_ncloudp, a_ncloudt, a_mcloudp, a_mcloudt,                              &
-       a_nprecpp, a_nprecpt, a_mprecpp, a_mprecpt, mc_ApVdom,					&
-	   a_nicep,   a_nicet,   a_micep,   a_micet,                                &
+       a_nprecpp, a_nprecpt, a_mprecpp, a_mprecpt, mc_ApVdom,         &
+       a_nicep,   a_nicet,   a_micep,   a_micet,                                &
        a_nsnowp,  a_nsnowt,  a_msnowp,  a_msnowt,                               &
-	   snowin,    prtcl
+       snowin,    prtcl
   use thrm, only : thermo
   use stat, only : sflg, updtst, acc_removal, mcflg, acc_massbudged
   implicit none
@@ -79,8 +79,6 @@ contains
     case(3)
        call mcrph(nzp,nxp,nyp,dn0,a_theta,a_scr1,a_rv,a_scr2,a_rc,a_rpp,   &
                   a_npp,precip,a_rt,a_tt,a_rpt,a_npt)
-
-
     case(4,5)
        IF (level < 5) sed_ice = .FALSE.; sed_snow = .FALSE.
        nn = GetNcomp(prtcl)+1
@@ -785,7 +783,7 @@ contains
     INTEGER, INTENT(in) :: nn             ! Number of bins
     REAL, INTENT(in) :: tk(n1,n2,n3)      ! Absolute temprature
     REAL, INTENT(in) :: adn(n1,n2,n3)     ! Air density
-    REAL, INTENT(in) :: pdn  ! Particle density ! VOISI ANTAA BINEITTÄINKIN JNE
+    REAL, INTENT(in) :: pdn  ! Particle density
     REAL, INTENT(in) :: rwet(n1,n2,n3,nn) ! Particle wet radius
     REAL, INTENT(in) :: numc(n1,n2,n3,nn) ! Particle number concentrations
     REAL, INTENT(in) :: dzt(n1)           ! Inverse of grid level thickness
@@ -869,7 +867,7 @@ contains
     INTEGER, INTENT(in) :: nn                ! Number of bins
     REAL, INTENT(in) :: tk(n1,n2,n3)         ! Absolute temprature
     REAL, INTENT(in) :: adn(n1,n2,n3)        ! Air density
-    REAL, INTENT(in) :: pdn                  ! Particle density !!! VOISI ANTAA BINEITTÄINKIN JNE
+    REAL, INTENT(in) :: pdn                  ! Particle density
     REAL, INTENT(in) :: rwet(n1,n2,n3,nn)    ! Particle wet radius
     REAL, INTENT(in) :: numc(n1,n2,n3,nn)    ! Particle number concentration
     REAL, INTENT(in) :: mass(n1,n2,n3,nn*n4) ! Particle mass mixing ratio
@@ -1018,7 +1016,7 @@ contains
 
              IF (rwet(k,i,j,bin) < 20.e-6 ) THEN
                 vc = (2.*(rwet(k,i,j,bin)**2)*(pdn-adn(k,i,j))*g/(9.*avis))*GG
-				vc = MIN(vc,1.)
+                vc = MIN(vc,1.)
              ELSE
                 vc = 2.e3*(2.*rwet(k,i,j,bin))*(rhoref/adn(k,i,j))**2
                 vc = MIN(vc,5.) 

--- a/src/src_LES/mpi_interface.f90
+++ b/src/src_LES/mpi_interface.f90
@@ -53,6 +53,8 @@ module mpi_interface
   integer :: stridetype,xstride,ystride,xystride,xylarry,xyzlarry,&
        fxytype,fxyztype
 
+  CHARACTER(len=80) :: ver='latest', author='Bjorn Stevens'
+
 contains
   !
   !----------------------------------------------------------------------
@@ -90,8 +92,8 @@ contains
     end select
     !
     call date_and_time(date)
-    if (myid == 0) print "(/1x,75('-'),/2x,A13,A8,/2x,A15,I2,A15,I2,A14)", &
-         'UCLA LES 2.0 ',date, 'Computing using',nbytes,' byte reals and', &
+    if (myid == 0) print "(/1x,75('-'),/2x,A22,1x,A8,/2x,A15,I2,A15,I2,A14)", &
+         'UCLALES-SALSA '//trim(ver),date, 'Computing using',nbytes,' byte reals and', &
          intsize," byte integers"
 
   end subroutine init_mpi

--- a/src/src_LES/ncio.f90
+++ b/src/src_LES/ncio.f90
@@ -46,7 +46,7 @@ contains
        iret = nf90_put_att(ncid,NF90_GLOBAL,'title',ename)
        iret = nf90_put_att(ncid,NF90_GLOBAL,'history','Created on '//date)
        iret = nf90_put_att(ncid, NF90_GLOBAL, 'Source','UCLALES-SALSA Version '//trim(version))
-       IF (LEN(trim(author))>0) iret = nf90_put_att(ncid, NF90_GLOBAL, 'Author',trim(author))
+       iret = nf90_put_att(ncid, NF90_GLOBAL, 'Author',trim(author))
        iret = nf90_put_att(ncid, NF90_GLOBAL, '_FillValue',-999.)
        iret = nf90_put_att(ncid, NF90_GLOBAL, 'NPTS',npts)
        iret = nf90_put_att(ncid, NF90_GLOBAL, 'NPROCS',pecount)
@@ -169,7 +169,7 @@ contains
 
        ! Juha: dimension environments for size distribution variables
        dim_ttttaea = (/ztID,xtID,ytID,aeaID,timeID/)
-       dim_ttttaeb = (/xtID,xtID,ytID,aebID,timeID/)
+       dim_ttttaeb = (/ztID,xtID,ytID,aebID,timeID/)
        dim_ttttcla = (/ztID,xtID,ytID,claID,timeID/)
        dim_ttttclb = (/ztID,xtID,ytID,clbID,timeID/)
        dim_ttttprc = (/ztID,xtID,ytID,prcID,timeID/)
@@ -572,6 +572,10 @@ contains
        if (itype==2) ncinfo = 'time'
     case('nrcnt')
        if (itype==0) ncinfo = 'Rain cell counts'
+       if (itype==1) ncinfo = '#'
+       if (itype==2) ncinfo = 'time'
+    case('nccnt')
+       if (itype==0) ncinfo = 'Cloud cell counts'
        if (itype==1) ncinfo = '#'
        if (itype==2) ncinfo = 'time'
     !
@@ -1826,9 +1830,7 @@ contains
     INTEGER :: iret, vid
 
     iret = nf90_inq_varid(ncid,name,vid)
-    IF ( iret /= NF90_NOERR) WRITE(*,*) 'ei löyry'
     iret = nf90_get_var(ncid,vid,var)
-    IF ( iret /= NF90_NOERR) WRITE(*,*) 'ei lue'
 
   END SUBROUTINE read_aero_nc_2d
   !

--- a/src/src_LES/ncio.f90
+++ b/src/src_LES/ncio.f90
@@ -14,13 +14,14 @@ contains
   ! ----------------------------------------------------------------------
   ! Subroutine Open_NC: Opens a NetCDF File and identifies starting record
   !
-  subroutine open_nc (fname, ename, time, npts, ncid, nrec)
+  subroutine open_nc (fname, ename, time, npts, ncid, nrec, version, author)
 
     integer, intent(in)             :: npts
     integer, intent(out)            :: ncid
     integer, intent(out)            :: nrec
     real, intent (in)               :: time
     character (len=80), intent (in) :: fname, ename
+    CHARACTER(LEN=80) :: version, author
 
     real, allocatable :: xtimes(:)
 
@@ -44,8 +45,8 @@ contains
 
        iret = nf90_put_att(ncid,NF90_GLOBAL,'title',ename)
        iret = nf90_put_att(ncid,NF90_GLOBAL,'history','Created on '//date)
-       iret = nf90_put_att(ncid, NF90_GLOBAL, 'Source','UCLA-LES Version 2.0')
-       iret = nf90_put_att(ncid, NF90_GLOBAL, 'Author','Bjorn Stevens')
+       iret = nf90_put_att(ncid, NF90_GLOBAL, 'Source','UCLALES-SALSA Version '//trim(version))
+       IF (LEN(trim(author))>0) iret = nf90_put_att(ncid, NF90_GLOBAL, 'Author',trim(author))
        iret = nf90_put_att(ncid, NF90_GLOBAL, '_FillValue',-999.)
        iret = nf90_put_att(ncid, NF90_GLOBAL, 'NPTS',npts)
        iret = nf90_put_att(ncid, NF90_GLOBAL, 'NPROCS',pecount)

--- a/src/src_LES/rad_corkds.f90
+++ b/src/src_LES/rad_corkds.f90
@@ -163,11 +163,11 @@ contains
     do ib = 1, mb
        if(isSolar(band(ib))) then
           if(i > size(solar_bands)) stop 'TERMINATING: mismatch in solar bands'
-          solar_bands(i) = copy_band_properties(band(ib)) 
+          solar_bands(i) = band(ib)
           i = i + 1
        else
-          if(j > size(ir_bands))    stop 'TERMINATING: mismatch in solar bands'
-          ir_bands(j) = copy_band_properties(band(ib)) 
+          if(j > size(ir_bands))    stop 'TERMINATING: mismatch in IR bands'
+          ir_bands(j) = band(ib)
           j = j + 1
        end if
     end do
@@ -405,30 +405,5 @@ contains
     
     isSolar = thisBand%power > 0. 
   end function isSolar
-  !
-  ! ----------------------------------------------------------------------
-  !
-  function copy_band_properties(original) result(copy)
-
-    type(band_properties), intent(in) :: original 
-    type(band_properties)             :: copy
-        
-    copy%kg     = original%kg
-    copy%ngases = original%ngases
-    copy%llimit = original%llimit
-    copy%rlimit = original%rlimit
-    copy%center = original%center
-    copy%power  = original%power
-    
-    if(allocated(original%gas_id)) then
-       allocate(copy%gas_id(size(original%gas_id)))
-       copy%gas_id(:) = original%gas_id(:)
-    end if
-    
-    if(allocated(original%hk)) then
-       allocate(copy%hk(size(original%hk)))
-       copy%hk(:) = original%hk(:)
-    end if
-  end function copy_band_properties
 
 end module ckd

--- a/src/src_LES/rad_corkds.f90
+++ b/src/src_LES/rad_corkds.f90
@@ -57,7 +57,7 @@ contains
   ! that it conforms to expected properties
   !
   subroutine init_ckd
-
+    use mpi_interface, only: myid
     implicit none
 
     integer :: i, j, k, l, n, ib, ii, mbs, mbir
@@ -65,7 +65,7 @@ contains
     real    :: bllmx, brlmn
     real, dimension(2000) :: realVars 
 
-    real, allocatable :: gasesinband(:)
+    INTEGER, allocatable :: gasesinband(:)
 
     OPEN ( unit = 66, file = trim(gasfile), status = 'old' )
     read (66, '(2I5)') mb, ngases
@@ -80,7 +80,7 @@ contains
        band(ib)%power = realVars(ib) 
     end do 
 
-    mbs = 0.
+    mbs = 0
     do ib=1,mb-1
        band(ib)%rlimit = band(ib+1)%llimit
        band(ib)%center =(band(ib)%rlimit+band(ib)%llimit)*0.5
@@ -90,7 +90,7 @@ contains
 
     if (band(mb)%power > 0.) mbs = mbs + 1
     mbir = mb - mbs
-    print 600, trim(gasfile), ngases, mb, mbs, mbir, sum(band%power)
+    IF (myid==0) print 600, trim(gasfile), ngases, mb, mbs, mbir, sum(band%power)
 
     do n=1,ngases
        read (66,'(A5,I4)') gas(n)%name,gas(n)%iband
@@ -116,7 +116,7 @@ contains
        end do 
 
        if (abs(sum(gas(n)%hk) - 1.) <= 1.1 * spacing(1.) ) then
-          print 601, gas(n)%name, gas(n)%iband, gas(n)%noverlap,              &
+          IF (myid==0) print 601, gas(n)%name, gas(n)%iband, gas(n)%noverlap, &
                gas(n)%ng, gas(n)%np, gas(n)%nt
        else
           print *, gas(n)%hk, sum(gas(n)%hk(:))
@@ -173,10 +173,10 @@ contains
     end do
     
     do ib=1,mb
-       print 602, ib, band(ib)%power, band(ib)%llimit, band(ib)%rlimit,    &
+       IF (myid==0) print 602, ib, band(ib)%power, band(ib)%llimit, band(ib)%rlimit, &
             band(ib)%ngases, band(ib)%kg
     end do
-    print 604
+    IF (myid==0) print 604
 
     Initialized = .True.
 

--- a/src/src_LES/rad_driver.f90
+++ b/src/src_LES/rad_driver.f90
@@ -29,6 +29,7 @@ module radiation
   implicit none
 
   character (len=50) :: background = 'datafiles/dsrt.lay'
+  LOGICAL :: McICA = .TRUE.
 
   logical, save     :: first_time = .True.
   real, allocatable, save ::  pp(:), pt(:), ph(:), po(:), pre(:), pde(:), &
@@ -41,7 +42,7 @@ module radiation
   contains
 
     subroutine d4stream(n1, n2, n3, alat, time, sknt, sfc_albedo, CCN, dn0, &
-         pi0, pi1, dzm, pip, tk, rv, rc, tt, rflx, sflx, albedo, rr, CDNC, radsounding)
+         pi0, pi1, dzm, pip, tk, rv, rc, tt, rflx, sflx, albedo, rr, CDNC, radsounding, useMcICA)
 
 
       integer, intent (in) :: n1, n2, n3
@@ -53,6 +54,7 @@ module radiation
       ! Juha added
       REAL, OPTIONAL, DIMENSION(n1,n2,n3), INTENT(in)   :: CDNC
       CHARACTER(len=50), OPTIONAL, INTENT(in)           :: radsounding
+	  LOGICAL, OPTIONAL                                     :: useMcICA
       real, intent (out)                                :: albedo(n2,n3)
 
       integer :: kk
@@ -60,6 +62,7 @@ module radiation
       xfact = 0.0; prw = 0.0; p0 = 0.0; exner = 0.0; pres = 0.0;
       IF (PRESENT(radsounding)) background = radsounding ! Juha: Added; can change the background
                                                          ! profile file from the NAMELIST
+      IF (PRESENT(useMcICA)) McICA = useMcICA
 
       if (first_time) then
          p0(n1) = (p00*(pi0(n1)/cp)**cpr) / 100.
@@ -146,7 +149,7 @@ module radiation
             
 
             call rad( sfc_albedo, u0, SolarConstant, sknt, ee, pp, pt, ph, po,&
-                 fds, fus, fdir, fuir, plwc=plwc, pre=pre, useMcICA=.True.)
+                 fds, fus, fdir, fuir, plwc=plwc, pre=pre, useMcICA=McICA)
 
             do k=1,n1
                kk = nv1 - (k-1)

--- a/src/src_LES/rad_driver.f90
+++ b/src/src_LES/rad_driver.f90
@@ -44,7 +44,6 @@ module radiation
     subroutine d4stream(n1, n2, n3, alat, time, sknt, sfc_albedo, CCN, dn0, &
          pi0, pi1, dzm, pip, tk, rv, rc, tt, rflx, sflx, albedo, rr, CDNC, radsounding, useMcICA)
 
-
       integer, intent (in) :: n1, n2, n3
       real, intent (in)    :: alat, time, sknt, sfc_albedo, CCN
       real, dimension (n1), intent (in)                 :: dn0, pi0, pi1, dzm
@@ -54,7 +53,7 @@ module radiation
       ! Juha added
       REAL, OPTIONAL, DIMENSION(n1,n2,n3), INTENT(in)   :: CDNC
       CHARACTER(len=50), OPTIONAL, INTENT(in)           :: radsounding
-	  LOGICAL, OPTIONAL                                     :: useMcICA
+      LOGICAL, OPTIONAL                                     :: useMcICA
       real, intent (out)                                :: albedo(n2,n3)
 
       integer :: kk
@@ -65,9 +64,15 @@ module radiation
       IF (PRESENT(useMcICA)) McICA = useMcICA
 
       if (first_time) then
-         p0(n1) = (p00*(pi0(n1)/cp)**cpr) / 100.
-         p0(n1-1) = (p00*(pi0(n1-1)/cp)**cpr) / 100.
-         call setup(background,n1,npts,nv1,nv,p0)
+         IF (.TRUE.) THEN
+            ! Works well with the LES model
+            p0(1:n1) = 0.01*p00*( (pi0(1:n1)+pi1(1:n1))/cp )**cpr
+            call setup_les(background,n1,nv1,nv,p0,tk(n1,3,3),rv(n1,3,3))
+         ELSE
+            p0(n1) = (p00*(pi0(n1)/cp)**cpr) / 100.
+            p0(n1-1) = (p00*(pi0(n1-1)/cp)**cpr) / 100.
+            call setup(background,n1,npts,nv1,nv,p0)
+         ENDIF
          first_time = .False.
          if (allocated(pre))   pre(:) = 0.
          if (allocated(pde))   pde(:) = 0.
@@ -77,25 +82,6 @@ module radiation
          if (allocated(pgwc)) pgwc(:) = 0.
          if (allocated(nc)) nc(:) = 0.
       end if
-      !
-      ! ------------------------------------------------------------------------------------------
-      ! Tomi Raatikainen 17.6.2016: fix problem related to ovelapping LES pressure levels
-      !
-      ! The lowest LES model pressure levels (without contribution from variable pip)
-      !             n1 - Pressure levels for LES: starts from below surface and is defined for cell centers
-      !             nv1 - Pressure levels for the radiation model (nv=nv1-1): starts from TOA and is defined for cell edges
-      pres(n1)=p00 * ((pi0(n1)+pi1(n1))/cp)**cpr
-      pres(n1-1)=p00 * ((pi0(n1-1)+pi1(n1-1))/cp)**cpr
-      ! Pressure for the last cell edge
-      pp(nv1-n1+1) = pres(n1)/100. - 0.5*(pres(n1-1)-pres(n1)) / 100.
-      ! This must be larger (e.g. by 1 hPa) than the obove radiation model pressure level (nv1-n1+1-1=nv1-n1)
-      if ( pp(nv1-n1+1) < pp(nv1-n1)+1.0 ) THEN
-         ! Simple solution to the problem: remove sounding level nv1-n1, which means that LES data is written over that
-         nv1=nv1-1       ! This should do it (start from the previos location)
-         nv=nv-1
-         WRITE(*,*) 'LES model pressure levels ovelapping with radiation soundings - removing the lowest sounding level!'
-      endif
-      ! ------------------------------------------------------------------------------------------
       !
       ! initialize surface albedo, emissivity and skin temperature.
       !
@@ -111,13 +97,25 @@ module radiation
       prw = (4./3.)*pi*rowt
       do j=3,n3-2
          do i=3,n2-2
-            do k=1,n1
-               exner(k)= (pi0(k)+pi1(k)+pip(k,i,j))/cp
-               pres(k) = p00 * (exner(k))**cpr
-            end do
-            pp(nv1) = 0.5*(pres(1)+pres(2)) / 100.
+            ! Grid cell pressures in the LES model (Pa)
+            exner(1:n1) = (pi0(1:n1)+pi1(1:n1)+pip(1:n1,i,j))/cp
+            pres(1:n1) = p00*( exner(1:n1) )**cpr
+
+            ! LES and background pressure levels must be separate (LES pressure levels will change)
+            !      Tomi Raatikainen 17.6.2016 & 21.12.2016
+            pp(nv-n1+2) = pres(n1)/100. - 0.5*(pres(n1-1)-pres(n1)) / 100.
+            if ( pp(nv-n1+2) < pp(nv-n1+1)+1.0 ) THEN
+                ! Simple solution to the problem: remove sounding level nv-n1+1, which means that LES data is written over that
+                nv1=nv1-1       ! This should do it (start from the previos location)
+                nv=nv-1
+                pp(nv-n1+2) = pres(n1)/100. - 0.5*(pres(n1-1)-pres(n1)) / 100. ! Update
+
+                WRITE(*,*) 'Warning (radiation/d4stream): ovelapping pressure levels observed (i,j)!',i,j
+            endif
+
             do k=2,n1
                kk = nv-(k-2)
+               pp(kk+1) = 0.5*(pres(k-1)+pres(k)) / 100.
                pt(kk) = tk(k,i,j)
                ph(kk) = rv(k,i,j)
                if (present(rr)) then
@@ -134,22 +132,14 @@ module radiation
 
                   pre(kk) = MERGE( 1.e6*(plwc(kk)/(1000.*prw*MAX(nc(kk),1.e-20)))**(1./3.), 0.,  &
                                   ( plwc(kk) > 0. .AND. nc(kk) > 0. ) )
-                  if (k < n1) pp(kk) = 0.5*(pres(k)+pres(k+1)) / 100.
                ELSE
                   pre(kk)  = 1.e6*(plwc(kk)/(1000.*prw*CCN*dn0(k)))**(1./3.)
                   if (plwc(kk).le.0.) pre(kk) = 0.
-                  if (k < n1) pp(kk) = 0.5*(pres(k)+pres(k+1)) / 100.
                END IF
             end do
-            pp(nv-n1+2) = pres(n1)/100. - 0.5*(pres(n1-1)-pres(n1)) / 100.
-
-            !IF (ANY(nc /= nc)) write(*,*) 'SÄTEILY1', pre
-            !IF (ANY(nc /= nc)) write(*,*) 'SÄTEILY2', nc
-            !IF (ANY(nc /= nc)) write(*,*) 'SÄTEILY3', plwc
-            
 
             call rad( sfc_albedo, u0, SolarConstant, sknt, ee, pp, pt, ph, po,&
-                 fds, fus, fdir, fuir, plwc=plwc, pre=pre, useMcICA=McICA)
+                 fds, fus, fdir, fuir, McICA, plwc=plwc, pre=pre)
 
             do k=1,n1
                kk = nv1 - (k-1)
@@ -274,6 +264,132 @@ module radiation
     end if
 
   end subroutine setup
+  !
+  ! ---------------------------------------------------------------------------
+  ! This version of setup is modified for LES simulations
+  !    - Always using background soundings and LES data
+  !    - Separate LES and background profiles
+  !    - Weighting of the backgound towards smooth transition at the interface
+  !
+  ! Tomi Raatikainen, 22.12.2016
+  !
+  subroutine setup_les(background,n1,nv1,nv,zp,ttop,qtop)
+    use mpi_interface, only: myid
+    implicit none
+
+    character (len=19), intent (in) :: background
+    integer, intent (in) :: n1
+    integer, intent (out):: nv1,nv
+    real, intent (in)    :: zp(n1), ttop, qtop
+
+    real, allocatable  :: sp(:), st(:), sh(:), so(:), sl(:)
+
+    integer :: k, ind, ns, nb, nt
+    real    :: ptop, dp, ptmp, Tsurf
+
+    ! Read backgroud profiles (p [hPa], T [K], q [kg/kg], O3 [-] and an unused concentration)
+    open ( unit = 08, file = background, status = 'old' )
+    read (08,*) Tsurf, ns
+    allocate ( sp(ns), st(ns), sh(ns), so(ns), sl(ns))
+    do k=1,ns
+       read ( 08, *) sp(k), st(k), sh(k), so(k), sl(k)
+    enddo
+    close (08)
+
+    ! Merge background and LES pressure levels (p_LES > p_background)
+    !
+    ! The highest LES model pressure - defined for cell interface
+    ptop=zp(n1)-0.5*(zp(n1-1)-zp(n1))
+    !
+    ! The first sounding level must be somewhat higher (lower pressure) then the last LES pressure level
+    !  - Must avoid overlapping pressure levels when LES pressures change with time
+    !  - 10 hPa should be large enough for most cases (LES has typically high pressure resolution)
+    dp=MAX(10.0,zp(n1-1)-zp(n1))
+    !
+    k=1 ! Note: increasing pressure and decreasing altitude
+    DO WHILE (sp(k) < ptop-dp )
+        k=k+1
+        IF (k==ns+1) EXIT
+    END DO
+    nb=k-1 ! Background soundings from 1 to k (nb points)
+
+    ! Add layers between LES and soundings (mind the gap!)
+    nt=0 ! Transition regime
+    IF (nb>0) nt=FLOOR( (ptop-sp(nb))/dp )-1
+
+    ! Include complete LES grid (n1 points), soundings (nb points) and the transition regime (nt points)
+    nv1 = n1+nb+nt  ! Total number of pressure points (cell interfaces)
+    nv = nv1-1   ! Total number of scalars (cell centers)
+
+    ! allocate the arrays for the sounding data to be used in the radiation
+    ! profile and then fill them first with the sounding data, by afill, then
+    ! by interpolating the background profile at pressures less than the
+    ! pressure at the top of the sounding
+    !
+    ! Note: LES pressure levels are increasing, but radiation calculations
+    ! expect decreasing pressure grid (from TOA to surface)
+    !
+    allocate (pp(nv1),fds(nv1),fus(nv1),fdir(nv1),fuir(nv1)) ! Cell interfaces
+    allocate (pt(nv),ph(nv),po(nv),pre(nv),pde(nv),plwc(nv),prwc(nv),nc(nv)) ! Cell centers
+
+    po=0.
+    IF (nb>0) THEN
+        ! Levels above LES domain: copy background soundings
+        pp(1:nb) = sp(1:nb)
+        pt(1:nb) = st(1:nb)
+        ph(1:nb) = sh(1:nb)
+        po(1:nb) = so(1:nb)
+    ENDIF
+
+    IF (nt>0) THEN
+        ! Interpolated levels between pp(nb) and ptop
+        DO k=1,nt
+            pp(nb+k)=pp(nb+k-1)-(pp(nb)-ptop)/REAL(nt+1)
+            ! Interpolate between LES model top and the lowest sounding
+            !   y=y0+(y1-y0)(p1-p0)*(p-p0)
+            ind = getindex(sp,ns,pp(nb+k)) ! Typically ind=nb
+            pt(nb+k)=ttop+(st(ind)-ttop)/(sp(ind)-ptop)*(pp(nb+k)-ptop)
+            ph(nb+k)=qtop+(sh(ind)-qtop)/(sp(ind)-ptop)*(pp(nb+k)-ptop)
+            ! Interpolate ozone using background soundings
+            po(nb+k)=so(ind+1)+(so(ind)-so(ind+1))/(sp(ind)-sp(ind+1))*(pp(nb+k)-sp(ind+1))
+        ENDDO
+    ENDIF
+
+    ! Within the LES domain
+    !  a) pressure, temperature and humidity will be obtained from the LES
+    !  b) set the ozone to a constant value
+    IF (nb+nt>0) po(nb+nt+1:nv) = po(nb+nt)
+
+    ! Print information about sounding
+    IF (myid==0) THEN
+        WRITE(*,'(/,/,20A)') '-------------------------------------------------'
+        WRITE(*,'(/2x,20A,/)') 'Reading Background Sounding: '//trim(background)
+        WRITE(*,'(/2x,A7,4A10)') 'Source','p (hPa)','T (K)','q (g/kg)','O3 (ppm)'
+
+        ! Calculate LES pressure levels ([zp]=hPa) and T and q for cell centers
+        pp(nv-n1+2) = zp(n1)/100. - 0.5*(zp(n1-1)-zp(n1))
+        do k=2,n1
+             pp(nv-(k-2)+1) = 0.5*(zp(k-1)+zp(k))
+        ENDDO
+
+        DO k=1,nv
+            IF (k<=nb .AND. nb>0) THEN
+                ! Data from backgound soundings
+                WRITE(*,'(2x,A7,2F10.2,2F10.3)') 'Backgr',pp(k),pt(k),ph(k)*1.e3,po(k)*1.e6
+            ELSEIF (k<=nb+nt .AND. nt>0) THEN
+                ! Interpolation
+                WRITE(*,'(2x,A7,2F10.2,2F10.3)') 'Interp',pp(k),pt(k),ph(k)*1.e3,po(k)*1.e6
+            ELSEIF (k==nb+nt+1) THEN
+                ! The highest LES layer - other layers not yet available
+                WRITE(*,'(2x,A7,2F10.2,2F10.3)') 'LES',ptop,ttop,qtop*1.e3,po(k)*1.e6
+                !WRITE(*,'(2x,A7,3A10,F10.3)') 'LES','*','*','*',po(k)*1.e6
+                WRITE(*,'(2x,A7,4A10)') 'LES','...','...','...','...'
+            ENDIF
+        ENDDO
+        WRITE(*,*) ' '
+    ENDIF
+
+  end subroutine setup_les
   ! ---------------------------------------------------------------------------
   !  locate the index closest to a value
   !

--- a/src/src_LES/seq_interface.f90
+++ b/src/src_LES/seq_interface.f90
@@ -39,6 +39,7 @@ module mpi_interface
   integer :: nxnzp,nynzp
   integer :: wrxid, wryid, nxprocs, nyprocs
   integer, allocatable, dimension(:) :: xoffset, yoffset, nxpa, nypa
+  CHARACTER(len=80) :: ver='latest', author='Bjorn Stevens'
 
   ! these are the parameters used in the alltoallw call in the fft
 
@@ -77,8 +78,8 @@ contains
     end select
     !
     call date_and_time(date)
-    if (myid == 0) print "(/1x,75('-'),/2x,A13,A8,/2x,A15,I2,A15,I2,A14)", &
-         'UCLA LES 2.0 ',date, 'Computing using',nbytes,' byte reals and', &
+    if (myid == 0) print "(/1x,75('-'),/2x,A22,1x,A8,/2x,A15,I2,A15,I2,A14)", &
+         'UCLALES-SALSA '//trim(ver),date, 'Computing using',nbytes,' byte reals and', &
          intsize," byte integers"
 
   end subroutine init_mpi

--- a/src/src_LES/sgsm.f90
+++ b/src/src_LES/sgsm.f90
@@ -80,11 +80,11 @@ contains
     use grid, only : a_up, a_uc, a_ut, a_vp, a_vc, a_vt, a_wp, a_wc, a_wt    &
          , a_rv, a_rc, a_rp, a_tp, a_tt, a_sp, a_st, a_qt, a_qp, a_pexnr, a_theta  &
          , a_scr1, a_scr2, a_scr3, a_scr4, a_scr5, a_scr6, nscl, nxp, nyp    &
-         , nzp, nxyp, nxyzp, zm, dxi, dyi, dzt, dzm, dtlt, dtlv , th00, dn0  &
+         , nzp, zm, dxi, dyi, dzt, dzm, dtlt, dtlv , th00, dn0  &
          , pi0, pi1, newsclr, level, isgstyp, uw_sfc, vw_sfc, ww_sfc, wt_sfc &
          , wq_sfc
 
-    use util, only         : atob, azero, get_avg3
+    use util, only         : get_avg3
     use mpi_interface, only: cyclics, cyclicc
     use thrm, only         : bruvais, fll_tkrs
 
@@ -144,7 +144,7 @@ contains
          ,sz4,sz5,sz6,1,'sgs')
 
     call diff_prep(nzp,nxp,nyp,a_scr5,a_scr6,a_scr4,a_scr1)
-    call azero(nxyp,sxy1,a2=sxy2)
+    sxy1=0.; sxy2=0.
 
     call diff_vpt(nzp,nxp,nyp,dn0,dzm,dzt,dxi,dyi,dtlv,vw_sfc,sxy2,a_scr6     &
          ,a_scr5,a_scr1,a_vp,a_wp,a_vt,sz2)
@@ -170,16 +170,16 @@ contains
     !
     ! Diffuse scalars
     !
-    call azero(nxyzp,a_tt)
+    a_tt=0.
     do n=1,nscl
        call newsclr(n)
-       call azero(nxyp,sxy1)
-       call azero(nxyp,sxy2)
-       if ( associated(a_tp,a_sp) ) call atob(nxyp,wt_sfc,sxy1)
-       if ( associated(a_tp,a_sp) ) call atob(nxyp,wt_sfc,sxy2)
-       if ( associated(a_rp,a_sp) ) call atob(nxyp,wq_sfc,sxy1)
+       sxy1=0.
+       sxy2=0.
+       if ( associated(a_tp,a_sp) ) sxy1=wt_sfc
+       if ( associated(a_tp,a_sp) ) sxy2=wt_sfc
+       if ( associated(a_rp,a_sp) ) sxy1=wq_sfc
 
-       if (sflg) call azero(nxyzp,a_scr1)
+       if (sflg) a_scr1=0.
        if ( isgstyp <= 1) then
           call diffsclr(nzp,nxp,nyp,dtlt,dxi,dyi,dzm,dzt,dn0,sxy1,sxy2   &
                ,a_sp,a_scr2,a_st,a_scr1)

--- a/src/src_LES/srfc.f90
+++ b/src/src_LES/srfc.f90
@@ -73,10 +73,10 @@ contains
     use grid, only: nzp, nxp, nyp, a_up, a_vp, a_theta, a_rv, a_rp, zt, dzt, psrf, th00  &
          , umean, vmean, a_ustar, a_tstar, a_rstar, uw_sfc, vw_sfc, ww_sfc    &
          , wt_sfc, wq_sfc, dn0, level,dtl, a_sflx, a_rflx, precip, a_dn,  &
-	 W1,W2,W3, mc_ApVdom, dtlt
+        W1,W2,W3, mc_ApVdom, dtlt
     use thrm, only: rslf
     use stat, only: sfc_stat, sflg, mcflg, acc_massbudged
-    use mpi_interface, only : nypg, nxpg, double_array_par_sum,myid
+    use mpi_interface, only : nypg, nxpg, double_array_par_sum
 
 
     implicit none
@@ -98,10 +98,6 @@ contains
 
     REAL :: mctmp(nxp,nyp) ! Helper for mass concenrvation statistics
 
-    !    if(myid==5)  dthcon=100.0
-    !    if(myid==15)  dthcon=200.0
-
-
     ! Added by Juha
     SELECT CASE(level)
        CASE(1,2,3)
@@ -120,6 +116,7 @@ contains
           do i=3,nxp-2
              dtdz(i,j)=dthcon
              drdz(i,j)=drtcon
+             bfct(i,j) = g*zt(2)/(a_theta(2,i,j)*wspd(i,j)**2) ! TR: is this needed?
           end do
        end do
        zs = zt(2)/zrough

--- a/src/src_LES/thrm.f90
+++ b/src/src_LES/thrm.f90
@@ -102,7 +102,7 @@ contains
 
   SUBROUTINE SALSAthrm(level,n1,n2,n3,pp,pi0,pi1,th00,rv,tl,th,tk,p,rs,rh,rc,srp,ri,rsi,rhi,srs)
     USE defs, ONLY : R,Rm, cp, cpr, p00, alvl, alvi
-    USE grid, ONLY : a_dn ! Siirrä nää argumenteiksi!
+    USE grid, ONLY : a_dn
     IMPLICIT NONE
 
     INTEGER, INTENT(in) :: level,n1,n2,n3
@@ -111,18 +111,17 @@ contains
                         tl(n1,n2,n3)          ! liquid potential temp
     REAL, INTENT(in) :: th00
     REAL, INTENT(in) :: pi0(n1),pi1(n1)
-    REAL, INTENT(out) :: rc(n1,n2,n3),  &     ! Total cloud condensate mix rat
-                         rs(n1,n2,n3),  &     ! Saturation mix rat
+    REAL, INTENT(IN) :: rc(n1,n2,n3),  &  ! Total cloud condensate mix rat
+                         srp(n1,n2,n3)            ! Precipitation mix rat
+    REAL, INTENT(OUT) :: rs(n1,n2,n3),  &   ! Saturation mix rat
                          rh(n1,n2,n3),  &     ! Relative humidity
-                         srp(n1,n2,n3), &     ! Precipitation mix rat
                          th(n1,n2,n3),  &     ! Potential temperature
                          tk(n1,n2,n3),  &     ! Absolute temperature
-                         p(n1,n2,n3)          ! Air pressure
-
-    REAL, INTENT(out), OPTIONAL ::  ri(n1,n2,n3),  &     ! Total ice condensate mix rat        ! ice'n'snow
-                                    rsi(n1,n2,n3), &     ! Saturation mix rat over ice         ! ice'n'snow
-                                    rhi(n1,n2,n3), &     ! relative humidity                   ! ice'n'snow
-                                    srs(n1,n2,n3)        ! Snow mix rat                        ! ice'n'snow
+                         p(n1,n2,n3)           ! Air pressure
+    REAL, OPTIONAL, INTENT(IN) :: ri(n1,n2,n3),  &  ! Total ice condensate mix rat
+                         srs(n1,n2,n3)      ! Snow mix rat
+    REAL, OPTIONAL, INTENT(OUT) :: rsi(n1,n2,n3), & ! Saturation mix rat over ice
+                         rhi(n1,n2,n3)      ! relative humidity over ice
     REAL :: exner
     INTEGER :: k,i,j
     REAL :: thil

--- a/src/src_salsa/aerosol_thermodynamics.f90
+++ b/src/src_salsa/aerosol_thermodynamics.f90
@@ -1,11 +1,5 @@
 module aerosol_thermodynamics
 
-  
-    !use chamber_Parameters
-    !use chamber_Global, only: n_org_spc
-
-
-
    ! Prototype module for calculating water content and vapour pressures for 
    ! organic species condensing in a chamber study.
 
@@ -21,11 +15,6 @@ module aerosol_thermodynamics
    ! Queries concerning the use of this code through Gordon McFiggans, g.mcfiggans@manchester.ac.uk,
    ! Ownership: D. Topping, Centre for Atmospheric Sciences, University of Manchester, 2007
 
-	!implicit none   
-	!!glc- delcare vapour pure here, so that it can be accessed from the rates module
-	!real(), dimension(n_org_spc) :: vapour_pure
-	!!glc public
-	!public :: vapour_pure
 	contains
 
 

--- a/src/src_salsa/mo_constants.f90
+++ b/src/src_salsa/mo_constants.f90
@@ -3,98 +3,20 @@ MODULE mo_constants
   IMPLICIT NONE
 
 ! Universal constants
-  REAL, PARAMETER :: api   = 3.14159265358979323846 ! pi
-  REAL, PARAMETER :: asqrt2= 1.41421356237309504880
-! REAL, PARAMETER :: ar    = 8.314e3       ! universal gas constant in J/K/kmol
-  REAL, PARAMETER :: argas = 8.314409      ! universal gas constant (R) in J/K/mol
   REAL, PARAMETER :: avo   = 6.02214e23    ! Avogadro constant in 1/mol
-  REAL, PARAMETER :: ak    = 1.380662e-23  ! Boltzmann constant in J/K
-  REAL, PARAMETER :: stbo  = 5.67E-8       ! Stephan-Boltzmann constant in W/m2/K4
-  REAL, PARAMETER :: ap0   = 101325.       ! Standard pressure in Pa
 
 ! Molar weights in g/mol
-  REAL, PARAMETER :: amco2 = 44.011        ! molecular weight of carbon dioxide
-  REAL, PARAMETER :: amch4 = 16.043        ! molecular weight of methane
-  REAL, PARAMETER :: amo3  = 47.9982       ! molecular weight of ozone
-  REAL, PARAMETER :: amn2o = 44.013        ! molecular weight of N2O
-  REAL, PARAMETER :: amc11 =137.3686       ! molecular weight of CFC11
-  REAL, PARAMETER :: amc12 =120.9140       ! molecular weight of CFC12
-  REAL, PARAMETER :: amo2  = 31.9988       ! molecular weight of molecular oxygen
-  REAL, PARAMETER :: amw   = 18.0154       ! molecular weight of water vapor
   REAL, PARAMETER :: amd   = 28.970        ! molecular weight of dry air
 
 ! Dry air and water vapour thermodynamic constants
-  REAL, PARAMETER :: cpd   = 1005.46       ! specific heat of dry air at constant
-                                                  ! pressure in J/K/kg
-  REAL, PARAMETER :: cpv   = 1869.46       ! specific heat of water vapour at
-                                                  ! constant pressure in J/K/kg
   REAL, PARAMETER :: rd    = 287.05        ! gas constant for dry air in J/K/kg
   REAL, PARAMETER :: rv    = 461.51        ! gas constant for water vapour
                                                   ! in J/K/kg
-  REAL, PARAMETER :: rcpd  = 1.0/cpd       ! auxiliary constant in K*kg/J
-  REAL            :: vtmpc1= rv/rd-1.0     ! dimensionless auxiliary constant
-  REAL            :: vtmpc2= cpv/cpd-1.0   ! dimensionless auxiliary constant
-
-! H2O related constants  (liquid, ice, snow), phase change constants
-  REAL, PARAMETER :: rhoh2o = 1000.0        ! density of liquid water in kg/m3
-  REAL, PARAMETER :: rhosea = 1025.0        ! density of sea water in kg/m3
-  REAL, PARAMETER :: rhoice = 917.0         ! density of ice in kg/m3
-  REAL, PARAMETER :: rhosno = 300.0         ! density of snow in kg/m3
-  REAL, PARAMETER :: rhoiw  = rhoice/rhoh2o    ! density ratio (ice/water)
   REAL, PARAMETER :: alv    = 2.5008e6      ! latent heat for vaporisation in J/kg
   REAL, PARAMETER :: als    = 2.8345e6      ! latent heat for sublimation in J/kg
   REAL, PARAMETER :: alf    = als-alv          ! latent heat for fusion in J/kg
-  REAL, PARAMETER :: cpliq  = 4218.         ! specific heat for liquid water J/K/kg
-  REAL, PARAMETER :: cpsea  = 3994.         ! specific heat for sea water J/K/kg
-  REAL, PARAMETER :: cpice  = 2106.         ! specific heat for ice J/K/kg
-  REAL, PARAMETER :: cpsno  = 2090.         ! specific heat for snow J/K/kg
-  REAL, PARAMETER :: alice  = 2.1656        ! thermal conductivity of ice in W/K/m
-  REAL, PARAMETER :: alsno  = 0.31          ! thermal conductivity of snow in W/K/m
-  REAL, PARAMETER :: tmelt  = 273.15        ! melting temperature of ice/snow in K
 
 ! Earth and earth orbit parameters
-  REAL, PARAMETER :: a     = 6371000.0     ! radius of the earth in m
-  REAL, PARAMETER :: rae   = 0.1277E-2     ! ratio of atmosphere to earth radius
-  REAL, PARAMETER :: omega = .7292E-4      ! solid rotation velocity of the earth
-                                                  ! in 1/s
-  REAL, PARAMETER :: secperday = 86400.    ! seconds per day
   REAL, PARAMETER :: g     = 9.80665       ! gravity acceleration in m/s2
-  REAL, PARAMETER :: qg    = 1.0/g         ! inverse of gravity acceleration
- 
-! Constants used for computation of saturation mixing ratio
-! over liquid water (*c_les*) or ice(*c_ies*)
-  REAL, PARAMETER :: c1es  = 610.78           !
-  REAL, PARAMETER :: c2es  = c1es*rd/rv          !
-  REAL, PARAMETER :: c3les = 17.269           !
-  REAL, PARAMETER :: c3ies = 21.875           !
-  REAL, PARAMETER :: c4les = 35.86            !
-  REAL, PARAMETER :: c4ies = 7.66             !
-  REAL, PARAMETER :: c5les = c3les*(tmelt-c4les) !
-  REAL, PARAMETER :: c5ies = c3ies*(tmelt-c4ies) !
-  REAL, PARAMETER :: c5alvcp = c5les*alv/cpd     !
-  REAL, PARAMETER :: c5alscp = c5ies*als/cpd     !
-  REAL, PARAMETER :: alvdcp  = alv/cpd           !
-  REAL, PARAMETER :: alsdcp  = als/cpd           !
-
-! Specifications, thresholds, and derived constants for the following subroutines:
-! s_lake, s_licetemp, s_sicetemp, meltpond, meltpond_ice, update_albedo_ice_meltpond
-
-  REAL, PARAMETER :: dmix     = 10.0   ! mixed-layer depth of lakes in m
-  REAL, PARAMETER :: dmixsea  = 50.0   ! mixed-layer depth of ocean in m
-  REAL, PARAMETER :: dice     = 0.05   ! minimum ice thickness in m
-  REAL, PARAMETER :: dicepond = 0.01   ! minimum ice thickness of pond ice in m
-  REAL, PARAMETER :: dicelim  = 0.10   ! threshold ice thickness for pond closing in m
-  REAL, PARAMETER :: dpondmin = 0.01   ! minimum pond depth for pond fraction in m
-  REAL, PARAMETER :: albpondi = 0.30   ! albedo of pond ice
-
-  REAL, PARAMETER :: snicecond = alice/alsno * rhoh2o/rhosno
-  REAL, PARAMETER :: hcapmix   = rhoh2o*cpliq*dmix     ! heat capacity of lake mixed layer in J/K/m2
-  REAL, PARAMETER :: hcapice   = rhoice*cpice*dice     ! heat capacity of upper ice layer
-  REAL, PARAMETER :: hcapicep  = rhoice*cpice*dicepond ! heat capacity of upper pond ice layer
-  REAL, PARAMETER :: rhoilf    = rhoice*alf            ! [J/m3]
-  REAL, PARAMETER :: rhowlf    = rhoh2o*alf            ! [J/m3]
-  REAL, PARAMETER :: hcaprilf  = hcapmix/rhoilf        ! [m/K]
-  REAL, PARAMETER :: rilfhcap  = rhoilf/hcapmix        ! [K/m]
-  REAL, PARAMETER :: tfreez    = dice*rilfhcap         ! cooling below tmelt required to form dice
  
 END MODULE mo_constants

--- a/src/src_salsa/mo_salsa.f90
+++ b/src/src_salsa/mo_salsa.f90
@@ -1,11 +1,7 @@
 MODULE mo_salsa
 
   ! --------------------------------------------------------------------------
-  ! The SALSA subroutine:
-  ! paerml has been removed alltogether because it is rather useless
-  ! from this point. Replaced with pvols which is used for all the computation
-  ! anyway. Apparently paerml is needed by HAM, so the conversion between pvols
-  ! and paerml should be done there upon coupling.
+  ! The SALSA subroutine
   !
   ! Modified for the new aerosol datatype,
   ! Juha Tonttila, FMI, 2014.
@@ -24,21 +20,16 @@ CONTAINS
                    pc_h2so4, pc_ocnv,  pc_ocsv, pc_hno3,    &
                    pc_nh3,   paero,    pcloud,  pprecp,     &
                    pice, psnow,                             &
-                   pactd,    pw,       dbg2,    prtcl, time,level      )
+                   pactd,    pw,    prtcl, time,level      )
 
-    USE mo_salsa_properties
-    USE mo_salsa_dynamics
-    USE mo_salsa_nucleation
-    USE mo_salsa_update
-    USE mo_salsa_cloud ! included for autoconversion and cloud activation
-
+    USE mo_salsa_dynamics, only : coagulation, condensation
+    USE mo_salsa_update, ONLY : distr_update
+    USE mo_salsa_cloud, only : cloud_activation, autoconv2, &
+              ice_immers_nucl,ice_hom_nucl,ice_het_nucl,ice_melt, &
+              autosnow
 
     USE mo_submctl, ONLY :      &
-         pi6,                       & ! pi/6
-         avog,                      &
-         in1a,  in2a,               & ! size section and composition indices
-         in2b,  fn1a,               &
-         fn2a,  fn2b,               &
+         fn2b,               & ! size section and composition indices
          t_section,                 & ! For cloud bins
          ncld,                      &
          nprc,                      &
@@ -54,23 +45,9 @@ CONTAINS
          lsicimmers,                &
          lsicmelt,                  &
          lsdistupdate,              &
-         debug,                     &
-         rhosu, msu, mvsu,          & ! properties of compounds
-         rhono, mno,                &
-         rhonh, mnh,                &
-         rhooc, moc,                &
-         rhobc, mbc,                &
-         rhoss, mss,                &
-         rhowa,                     &
-         rhodu, mdu,                &
-         nlim,                      &
-         mvnh                       ! logical switch for recalculation of zdwet
-
+         debug
 
     USE class_componentIndex, ONLY : ComponentIndex
-
-    
-
 
     IMPLICIT NONE
 
@@ -94,8 +71,6 @@ CONTAINS
     REAL, INTENT(in) ::            & ! Vertical velocity
          pw(kbdim,klev)
 
-    LOGICAL, INTENT(in) :: dbg2!, testswitch
-
     !-- Input variables that are changed within --------------------------------------
     REAL, INTENT(inout) ::      & ! gas phase concentrations at each grid point [#/m3]
          pc_h2so4(kbdim,klev),      & ! sulphuric acid
@@ -106,14 +81,6 @@ CONTAINS
          prv(kbdim,klev),           & ! Water vapour mixing ratio  [kg/m3]
          prs(kbdim,klev),           & ! Saturation mixing ratio    [kg/m3]
          prsi(kbdim,klev)              ! Saturation mixing ratio over ice   [kg/m3]
-
-                                ! aerosol distribution properties at each grid point
-         !pm6rp (kbdim,klev,fn2b)   ,& ! mean mode actual radius (wet radius for soluble mode
-                                ! and dry radius for insoluble modes) [cm]
-         !pm6dry(kbdim,klev,fn2a)   ,& ! dry radius [cm]
-         !pww   (kbdim,klev,fn2b)   ,& ! aerosol water content for each mode [kg(water) m-3(air)]
-         !prhop (kbdim,klev,fn2b)   ,& ! mean mode particle density [g cm-3]
-         !ppbl(kbdim)               ,&
 
     TYPE(t_section), INTENT(inout) :: &
          pcloud(kbdim,klev,ncld),     &
@@ -127,102 +94,13 @@ CONTAINS
 
     INTEGER, INTENT(in) :: level                         ! thermodynamical level
 
-    INTEGER :: zpbl(kbdim)            ! Planetary boundary layer top level
-    !REAL :: zrh(kbdim,klev)           ! Relative humidity
-
-
-    !-- Output variables -----------------------------------------------------------------
-
-    !   in each bin
-
     !-- Local variables ------------------------------------------------------------------
 
-    LOGICAL::moving_center
-    INTEGER :: ii, jj, kk, nn
-
-    REAL :: zww(kbdim,klev,fn2b)
-    REAL :: zrhop(kbdim,klev,fn2b)
-
-
-    REAL ::                       &
-         zcore   (kbdim,klev,fn2b),   & ! volume of the core in one size bin
-         !zdwet   (kbdim,klev,fn2b),   &  ! EI TARVI??
-         zvq     (kbdim,klev,fn2b),   &
-         !zlwc    (kbdim,klev,fn2b),   & ! liquid water in a droplet in one size bin
-         zddry                          !EI TARVI??
+    INTEGER :: zpbl(kbdim)            ! Planetary boundary layer top level
 
     IF (debug) WRITE(*,*) 'start salsa'
 
-    moving_center=.false.
-
-    zcore = 0.
-    zddry = 0.
-    zpbl = 1
-
-
-    ! Nää tehdään jo LESsissä! Mutta tarvittaessa tyhjää binit tässäkin
-    ! SALSA-ajurissa tapahtuvan advektiotendenssikikkailun takia
-    DO kk = in1a,fn1a      ! size bin
-       DO jj = 1,klev      ! vertical grid
-          DO ii = 1,kproma ! horizontal grid
-             IF(paero(ii,jj,kk)%numc < nlim) CYCLE
-             zddry = (sum(paero(ii,jj,kk)%volc(1:2)) / &
-                       paero(ii,jj,kk)%numc/pi6)**(1./3.)
-             IF(zddry < 1.e-10) THEN
-  WRITE(*,*) 'hep!',paero(ii,jj,kk)%numc,kk
-                pc_h2so4(ii,jj)  = pc_h2so4(ii,jj) + paero(ii,jj,kk)%volc(1) * rhosu / msu * avog
-                pc_ocsv(ii,jj)   = pc_ocsv(ii,jj) + paero(ii,jj,kk)%volc(2) * rhooc / moc * avog
-                pc_hno3(ii,jj)   = pc_hno3(ii,jj) + paero(ii,jj,kk)%volc(6) * rhono / mno * avog
-                pc_nh3(ii,jj)    = pc_nh3(ii,jj)  + paero(ii,jj,kk)%volc(7) * rhonh / mnh * avog
-                paero(ii,jj,kk)%numc  = 0.0
-                paero(ii,jj,kk)%volc(:) = 0.0
-
- !               STOP 'hep!'
-             END IF
-          END DO
-       END DO
-    END DO
-
-    DO kk = in2a,fn2a      ! size bin
-       DO jj = 1,klev      ! vertical grid
-          DO ii = 1,kproma ! horizontal grid
-             IF(paero(ii,jj,kk)%numc < nlim) CYCLE
-             zddry = (sum(paero(ii,jj,kk)%volc(:)) / &
-                       paero(ii,jj,kk)%numc/pi6)**(1./3.)
-             IF(zddry < 1.e-10) THEN
-                WRITE(*,*) 'hep',paero(ii,jj,kk)%numc,kk,paero(ii,jj,kk)%volc(:), zddry
-                pc_h2so4(ii,jj)   = pc_h2so4(ii,jj) + paero(ii,jj,kk)%volc(1) * rhosu / msu * avog
-                pc_ocsv(ii,jj)    = pc_ocsv(ii,jj) + paero(ii,jj,kk)%volc(2) * rhooc / moc * avog
-                pc_hno3(ii,jj)   = pc_hno3(ii,jj) + paero(ii,jj,kk)%volc(6) * rhono / mno * avog
-                pc_nh3(ii,jj)    = pc_nh3(ii,jj)  + paero(ii,jj,kk)%volc(7) * rhonh / mnh * avog
-                paero(ii,jj,kk)%numc  = 0.0
-                paero(ii,jj,kk)%volc(:) = 0.0
-
-!                STOP 'hep'
-             END IF
-          END DO
-       END DO
-    END DO
-
-    DO kk = in2b,fn2b      ! size bin
-       DO jj = 1,klev      ! vertical grid
-          DO ii = 1,kproma ! horizontal grid
-             IF(paero(ii,jj,kk)%numc < nlim) CYCLE
-             zddry = (sum(paero(ii,jj,kk)%volc(:)) / &
-                       paero(ii,jj,kk)%numc/pi6)**(1./3.)
-             IF(zddry < 1.e-10) THEN
-                pc_h2so4(ii,jj)   = pc_h2so4(ii,jj) + paero(ii,jj,kk)%volc(1) * rhosu / msu * avog
-                pc_ocsv(ii,jj)    = pc_ocsv(ii,jj) + paero(ii,jj,kk)%volc(2) * rhooc / moc * avog
-                pc_hno3(ii,jj)   = pc_hno3(ii,jj) + paero(ii,jj,kk)%volc(6) * rhono / mno * avog
-                pc_nh3(ii,jj)    = pc_nh3(ii,jj)  + paero(ii,jj,kk)%volc(7) * rhonh / mnh * avog
-                paero(ii,jj,kk)%numc  = 0.0
-                paero(ii,jj,kk)%volc(:) = 0.0
-                !WRITE(*,*) 'he'
-                STOP 'he'
-             END IF
-          END DO
-       END DO
-    END DO
+    zpbl(:)=1
 
     ! Coagulation
     IF (lscoag) &
@@ -250,6 +128,7 @@ CONTAINS
                                ptemp,  ppres, prv,    &
                                prs,    pw,    paero,  &
                                pcloud, pactd          )
+
     ! Immersion freezing
     IF (lsicimmers) &
          CALL ice_immers_nucl(kproma,kbdim,klev,            &
@@ -284,78 +163,6 @@ CONTAINS
          CALL distr_update(kproma, kbdim, klev,     &
                            paero,  pcloud, pprecp,  &
                            pice, psnow, level       )
-
-    zww    = (pi6*paero(:,:,:)%dwet**3 - paero(:,:,:)%core)*rhowa*paero(:,:,:)%numc ! Lisää nitraattien kontrib
-
-    DO jj = 1,klev      ! vertical grid
-       DO ii = 1,kproma ! horizontal kproma in the slab
-
-          DO kk = in1a, fn1a
-             zvq(ii,jj,kk) = sum(paero(ii,jj,kk)%volc(1:2)) + &
-                  zww(ii,jj,kk)/ rhowa
-
-             ! check if enough aerosol mass present
-
-             IF(zvq(ii,jj,kk) > 1.e-30) THEN
-                zrhop(ii,jj,in1a:fn1a) = (paero(ii,jj,kk)%volc(1)*rhosu     &
-                     + paero(ii,jj,kk)%volc(2)*rhooc + zww(ii,jj,kk)) /     &
-                     zvq(ii,jj,kk)                                    &
-                     ! conversion from kg/m3 to g/cm3
-                     /1000.
-             ELSE
-
-                ! if not enough mass, assume density of water in g/cm3 to avoid NaN
-                zrhop(ii,jj,kk) = rhowa/1000.
-
-             END IF
-
-          END DO
-
-          DO kk = in2a, fn2a
-             zvq(ii,jj,kk) = sum(paero(ii,jj,kk)%volc(1:7))+                  &
-                             zww(ii,jj,kk)/rhowa
-
-             IF(zvq(ii,jj,kk) > 1.e-30) THEN
-
-                zrhop(ii,jj,kk) = (paero(ii,jj,kk)%volc(1)*rhosu +          &
-                                   paero(ii,jj,kk)%volc(2)*rhooc +          &
-                                   paero(ii,jj,kk)%volc(6)*rhono +          &
-                                   paero(ii,jj,kk)%volc(7)*rhonh +          &
-                                   paero(ii,jj,kk)%volc(3)*rhobc +          &
-                                   paero(ii,jj,kk)%volc(4)*rhodu +          &
-                                   paero(ii,jj,kk)%volc(5)*rhoss +          &
-                                   zww(ii,jj,kk))/                    &
-                                   zvq(ii,jj,kk) / 1000.
-
-             ELSE
-
-                zrhop(ii,jj,kk) = rhowa/1000.
-
-             END IF
-
-          END DO
-
-          DO kk = in2b, fn2b
-
-             zvq(ii,jj,kk) = sum(paero(ii,jj,kk)%volc(1:4)) + SUM(paero(ii,jj,kk)%volc(6:7)) + &
-                              zww(ii,jj,kk) / rhowa
-
-             IF(zvq(ii,jj,kk) > 1.e-30) THEN
-                zrhop(ii,jj,kk) = (paero(ii,jj,kk)%volc(1)*rhosu +          &
-                                   paero(ii,jj,kk)%volc(2)*rhooc +          &
-                                   paero(ii,jj,kk)%volc(6)*rhono +          &
-                                   paero(ii,jj,kk)%volc(7)*rhonh +          &
-                                   paero(ii,jj,kk)%volc(3)*rhobc +          &
-                                   paero(ii,jj,kk)%volc(4)*rhodu +          &
-                                   zww(ii,jj,kk))/                    &
-                                   zvq(ii,jj,kk)/1000.
-             ELSE
-                zrhop(ii,jj,kk) = rhobc/1000.
-             END IF
-
-          END DO
-       END DO
-    END DO
 
   END SUBROUTINE salsa
 

--- a/src/src_salsa/mo_salsa_cloud.f90
+++ b/src/src_salsa/mo_salsa_cloud.f90
@@ -1229,7 +1229,7 @@ CONTAINS
 
     REAL, INTENT(in) :: temp
     CHARACTER(len=*), INTENT(in) :: nucltype
-    REAL :: Tc
+    REAL :: Tc, a0, a1, a2, a3
     Tc = temp-273.15
 
     calc_act_energy = 0.
@@ -1254,7 +1254,7 @@ CONTAINS
   REAL FUNCTION calc_crit_energy(rn,prv,prs,temp) ! critical energy KC[00] (eq. 2.10)
     USE mo_submctl, ONLY : surfi0, pi
     REAL, INTENT(in) :: rn, prv,prs, temp
-    REAL :: mis, r_g, x, sigma_is,sigma_ns,sigma_ni
+    REAL :: mis, r_g, x, sigma_is,sigma_ns,sigma_ni,alpha
 
     sigma_is = surfi0!! surface tension of ice-solution interface
     sigma_ns = 1

--- a/src/src_salsa/mo_salsa_cloud.f90
+++ b/src/src_salsa/mo_salsa_cloud.f90
@@ -4,23 +4,12 @@ MODULE mo_salsa_cloud
   !  MO_SALSA_CLOUD
   !*********************************************************
   !
-  ! Purpose: Calculates the number of activated cloud
-  ! droplets according to parameterizations by:
-  !
-  ! Abdul-Razzak et al: "A parameterization of aerosol activation -
-  !                      3. Sectional representation"
-  !                      J. Geophys. Res. 107, 10.1029/2001JD000483, 2002.
-  !                      [Part 3]
-  !
-  ! Abdul Razzak et al: "A parameterization of aerosol activation -
-  !                      1. Single aerosol type"
-  !                      J. Geophys. Res. 103, 6123-6130, 1998.
-  !                      [Part 1]
+  ! Purpose: Calculates the number of activated cloud droplets
   !
   !
   ! Interface:
   ! ----------
-  ! Called from the salsa main subroutine
+  ! Called from the main aerosol model
   !
   !
   ! Coded by:
@@ -33,43 +22,13 @@ MODULE mo_salsa_cloud
 
 CONTAINS
 
-
-  ! NOTE: THE ACTIVATION PROCEDURES DO NOT CURRENTLY ACCOUNT FOR INSOLUBLE CORES!!!
-  ! *********************************************************************************
   SUBROUTINE cloud_activation(kproma, kbdim, klev,   &
                               temp,   pres,  rv,     &
                               rs,     w,     paero,  &
                               pcloud, pactd          )
 
-    USE mo_constants,   ONLY : g
-
-    USE mo_submctl, ONLY :                      &
-         lsactbase,                                 & ! Activation at cloud base
-         lsactintst,                                & ! Activation of interstitial particles
-         rg,                                        & ! molar gas constant
-                                                      ! [J/(mol K)]
-         slim,                                      &
-         surfw0,                                    & ! surface tension
-                                                      ! of water [J/m2]
-         !nbin,                                      & ! number of size bins
-                                                      ! in subranges
-         nlim,                                      & ! lowest possible particle conc. in a bin [#/m3]
-         rhosu, msu,                                & ! properties of compounds
-         rhooc, moc,                                &
-         rhono, mno,                                &
-         rhonh, mnh,                                &
-         rhobc, mbc,                                &
-         rhoss, mss,                                &
-         rhowa, mwa,                                &
-         rhodu, mdu,                                &
-         pi,                                        &
-         pi6,                                       &
-         cpa,                                       &
-         mair,                                      &
-         in1a,in2a,in2b,fn2a, fn2b,            & ! size regime bin indices
-         t_section,                                 & ! Data type for cloud/rain drops
-         t_parallelbin,                             & ! Data type for mapping indices between parallel size bins
-         ncld                                         ! Total number of cloud bins
+    USE mo_submctl, ONLY : t_section, fn2b, ncld, &
+              lsactintst, lsactbase
 
     IMPLICIT NONE
 
@@ -93,6 +52,144 @@ CONTAINS
     ! Properties of newly activate particles
     TYPE(t_section), INTENT(out) :: pactd(kbdim,klev,ncld)
 
+    INTEGER :: ii, jj, kk
+
+    ! This is needed for cloud base activation, but must be set to zero for interstitial activation
+    DO jj = 1,klev    ! vertical grid
+        DO ii = 1,kbdim ! horizontal grid
+            ! Reset activated
+            DO kk = 1,ncld
+                pactd(ii,jj,kk)%volc(:) = 0.
+                pactd(ii,jj,kk)%numc = 0.
+            END DO
+        END DO
+    END DO
+
+    ! -------------------------------------
+    ! Interstitial activation
+    ! -------------------------------------
+    IF ( lsactintst ) THEN
+
+       CALL actInterst(kproma,kbdim,klev,paero,pcloud,rv,rs,temp)
+
+    END IF
+
+    ! -----------------------------------
+    ! Activation at cloud base
+    ! -----------------------------------
+    IF ( lsactbase ) THEN
+
+        CALL ActCloudBase(kproma,kbdim,klev,paero,pcloud,pres,temp,w,pactd)
+
+    END IF
+
+  END SUBROUTINE cloud_activation
+
+
+! -----------------------------------------------------------------
+! Calculates the number of moles of dissolved solutes in one particle
+!
+  SUBROUTINE getSolute(kproma,kbdim,klev,paero,pns)
+    USE mo_submctl, ONLY : t_section,nlim,       &
+                               fn2b,            &
+                               rhosu, rhooc, rhobc,  &
+                               rhonh, rhono, rhodu,  &
+                               rhoss,                &
+                               msu, moc, mbc,        &
+                               mnh, mno, mdu,        &
+                               mss
+    IMPLICIT NONE
+
+    INTEGER, INTENT(IN) :: kproma,kbdim,klev
+    TYPE(t_section), INTENT(IN) :: paero(kbdim,klev,fn2b)
+    REAL, INTENT(OUT) :: pns(kbdim,klev,fn2b)
+
+    INTEGER :: ii,jj,kk
+
+    pns = 0.
+
+    DO jj = 1,klev
+
+       DO ii = 1,kbdim
+
+          !-- subranges 1a, 2a and 2b
+
+          DO kk = 1, fn2b
+             IF (paero(ii,jj,kk)%numc > nlim) THEN
+
+                !-- number of moles of solute in one particle [mol]
+                !   BC and dust are insoluble - ignored
+                !   SS or NaCl produces 2 ions
+                !   SO or H2SO4 produces 3 ions
+                pns(ii,jj,kk) = (3.*paero(ii,jj,kk)%volc(1)*rhosu/msu  +   &
+                     paero(ii,jj,kk)%volc(2) * rhooc/moc +                    &
+                     paero(ii,jj,kk)%volc(6) * rhono/mno +                    &
+                     paero(ii,jj,kk)%volc(7) * rhonh/mnh +                    &
+                     2.*paero(ii,jj,kk)%volc(5) * rhoss/mss)/              &
+                     paero(ii,jj,kk)%numc
+
+             END IF
+          END DO
+
+       END DO
+
+    END DO
+
+
+  END SUBROUTINE getSolute
+
+
+! -----------------------------------------------------------------
+
+  SUBROUTINE ActCloudBase(kproma,kbdim,klev,paero,pcloud,pres,temp,w,pactd)
+    ! Cloud base activation following:
+    !
+    ! Abdul-Razzak et al: "A parameterization of aerosol activation -
+    !                      3. Sectional representation"
+    !                      J. Geophys. Res. 107, 10.1029/2001JD000483, 2002.
+    !                      [Part 3]
+    !
+    ! Abdul Razzak et al: "A parameterization of aerosol activation -
+    !                      1. Single aerosol type"
+    !                      J. Geophys. Res. 103, 6123-6130, 1998.
+    !                      [Part 1]
+    !
+    !
+    ! Note: updates pactd, but does not change pcloud?
+    ! Note: insoluble species are not properly accounted for
+    !
+    USE mo_constants,   ONLY : g
+
+    USE mo_submctl, ONLY :     &
+         rg,                             & ! molar gas constant [J/(mol K)]
+         surfw0,                       & ! surface tension of water [J/m2]
+         nlim,                           & ! lowest possible particle conc. in a bin [#/m3]
+         rhowa, mwa,                & ! Density and molar mass of water
+         pi,                             &
+         cpa, mair,                    & ! Air properties
+         in1a,in2b,fn2a, fn2b,      & ! size regime bin indices
+         t_section,                    & ! Data type for cloud/rain drops
+         ncld                               ! Total number of cloud bins
+
+    IMPLICIT NONE
+
+    !-- Input and output variables ----------
+    INTEGER, INTENT(IN) ::              &
+             kproma,                    & ! number of horiz. grid points
+             kbdim,                     & ! dimension for arrays
+             klev                       ! number of vertical levels
+
+    REAL, INTENT(in) ::             &
+             pres(kbdim,klev),          &
+             temp(kbdim,klev),          &
+             w(kbdim,klev)
+
+    TYPE(t_section), INTENT(inout) :: pcloud(kbdim,klev,ncld),  &
+                                      paero(kbdim,klev,fn2b)
+
+    ! Properties of newly activate particles
+    TYPE(t_section), INTENT(out) :: pactd(kbdim,klev,ncld)
+
     !-- local variables --------------
     INTEGER :: ii, jj, kk             ! loop indices
 
@@ -103,16 +200,14 @@ CONTAINS
                                           !     at the upper bound of the bin
              siu,                       & !  "  at the lower bound of the bin
              scrit(fn2b),               & !  "  at the center of the bin
-             aa(kbdim,klev),                        & ! curvature (Kelvin) effect [m]
+             aa,                        & ! curvature (Kelvin) effect [m]
              bb,                        & ! solute (Raoult) effect [m3]
              ns(kbdim,klev,fn2b),                  & ! number of moles of solute
              nshi,                      & !             " at the upper bound of the bin
              nslo,                      & !             " at the lower bound of the bin
-             ratio,                     & ! volume ratio
-             vmiddle(kbdim,klev,fn2b),  & ! volume in the middle of the bin [m3]
              s_max,                     & ! maximum supersaturation
              s_eff,                     & ! effective supersaturation
-             x, x1, x2, x3, a1, sum1,   & ! technical variables
+             x, x1, a1, sum1,       & ! technical variables
              ka1,                       & ! thermal conductivity
              dv1,                       & ! diffusion coefficient
              Gc,                        & ! growth coefficient
@@ -124,30 +219,16 @@ CONTAINS
              theta,                     & ! see Abdul-Razzak and Ghan, part 3
              frac(kbdim,klev,fn2b),                & ! fraction of activated droplets in a bin
              ntot,                      & ! total number conc of particles [#/m3]
-             dinsol(fn2b),              & ! diameter of the insoluble fraction [m]
-             dinsolhi,                  & !    "   at the upper bound of a bin [m]
-             dinsollo,                  & !    "   at the lower bound of a bin [m]
              zdcrit(kbdim,klev,fn2b),   & ! critical diameter [m]
              zdcstar(kbdim,klev),                   & ! Critical diameter corresponding to Smax
-             !zdcint,                    &  ! Critical diameter for calculating activation of interstitial particles
-             !zvcrhi,zvcrlo,             & ! critical volume boundaries for partially activated bins
              zdcrhi(kbdim,klev,fn2b),   & ! Critical diameter at the high end of a bin
              zdcrlo(kbdim,klev,fn2b),   & ! Critical diameter at the low end of a bin
              V,                         & ! updraft velocity [m/s]
-             rref,                      & ! reference radius [m]
-             A, dmx,           & !
-             vlo, k,                    &
-             !zvact,               & ! Total volume concentration of the newly activated droplets
-             !zcoreact,            & ! Volume concentration of the newly activated dry CCN
-             !zvtot,               &
-             !zcore,               &
-             zrho(8)
-
+             rref                       ! reference radius [m]
 
     ! ------------------------------------------------------------------
     ! Initialization
     ! ------------------------------------------------------------------
-    zrho(1:8) = (/rhosu,rhooc,rhono,rhonh,rhobc,rhodu,rhoss,rhowa/)
 
     bb = 6.*mwa/(pi*rhowa)             ! Raoult effect [m3]
                                           ! NOTE!
@@ -161,61 +242,33 @@ CONTAINS
     bcrita(:,:) = fn2a
     bcritb(:,:) = fn2b
 
-    DO jj = 1,klev    ! vertical grid
-       DO ii = 1,kproma ! horizontal grid
-
-          vmiddle(ii,jj,in1a:fn2b) = pi6*paero(ii,jj,in1a:fn2b)%dmid**3
-          DO kk = 1,ncld
-             pactd(ii,jj,kk)%volc(:) = 0.
-             pactd(ii,jj,kk)%numc = 0.
-          END DO
-          aa(ii,jj) = 4.*mwa*surfw0/(rg*rhowa*temp(ii,jj)) ! Kelvin effect [m]
-
-       END DO
-    END DO
-
     ! Get moles of solute at the middle of the bin
     CALL getSolute(kproma,kbdim,klev,paero,ns)
 
     ! ----------------------------------------------------------------
 
-
-    ! -------------------------------------
-    ! Interstitial activation
-    ! -------------------------------------
-    IF ( lsactintst ) THEN
-
-       !write(*,*) 'ACT'
-       CALL actInterst(kproma,kbdim,klev,paero,pcloud,rv,rs,aa)
-
-       ! Update the moles of solute after interstitial activation
-       CALL getSolute(kproma,kbdim,klev,paero,ns)
-    END IF
-
-
-    ! -----------------------------------
-    ! Activation at cloud base
-    ! -----------------------------------
-    IF ( lsactbase ) THEN
-
        DO jj = 1,klev    ! vertical grid
-          DO ii = 1,kproma ! horizontal grid
+          DO ii = 1,kbdim ! horizontal grid
+             ! Reset activated - done already
+             !   pactd(ii,jj,kk)%volc(:) = 0.
+             !   pactd(ii,jj,kk)%numc = 0.
 
-             A  = aa(ii,jj) * 1.e6                            !     "         [um]
-             x  = 4.*aa(ii,jj)**3/(27.*bb)
+             ! Positive updraft velocity required
+             IF (w(ii,jj) <= 0.) CYCLE
+
+             aa = 4.*mwa*surfw0/(rg*rhowa*temp(ii,jj)) ! Kelvin effect [m]
+
+             x  = 4.*aa**3/(27.*bb)
 
              ! Get the critical supersaturation for aerosol bins for necessary summation terms (sum1 & ntot)
-             ntot = 0.
-             sum1 = 0.
 
              scrit(in1a:fn2b) = exp(sqrt(x/max(epsilon(1.0),ns(ii,jj,in1a:fn2b)))) - 1.
 
              !-- sums in equation (8), part 3
-             ntot = ntot + SUM(paero(ii,jj,in1a:fn2b)%numc)
-             sum1 = sum1 + SUM(paero(ii,jj,in1a:fn2b)%numc/scrit(in1a:fn2b)**(2./3.))
+             ntot = SUM(paero(ii,jj,in1a:fn2b)%numc)
+             sum1 = SUM(paero(ii,jj,in1a:fn2b)%numc/scrit(in1a:fn2b)**(2./3.))
 
              IF(ntot < nlim) CYCLE
-             IF (w(ii,jj) <= 0.) CYCLE
              V  = w(ii,jj)
 
              !-- latent heat of evaporation [J/kg]
@@ -257,14 +310,15 @@ CONTAINS
              theta = ((alpha*V/Gc)**(3./2.))/(2.*pi*rhowa*gamma*ntot)
 
              !-- part 3, equation (6)
-             khi = (2./3.)*aa(ii,jj)*SQRT(alpha*V/Gc)
+             khi = (2./3.)*aa*SQRT(alpha*V/Gc)
 
              !-- maximum supersaturation of the air parcel: part 3, equation (9)
              s_max = s_eff / SQRT(0.5*(khi/theta)**(3./2.)              &
                   + ((s_eff**2)/(theta+3.*khi))**(3./4.))
 
              !-- Juha: Get the critical diameter corresponding to the maximum supersaturation
-             zdcstar = 2.*aa(ii,jj)/(3.*s_max)
+             zdcstar = 2.*aa/(3.*s_max)
+
 
              DO kk = in1a, fn2b
 
@@ -288,9 +342,9 @@ CONTAINS
                 frac(ii,jj,kk) = min(1.,log(s_max/sil)/log(siu/sil))
 
                 !-- Critical diameters for each bin and bin edges
-                zdcrlo(ii,jj,kk) = 2.*sqrt(3.*nslo*bb/aa(ii,jj))
-                zdcrhi(ii,jj,kk) = 2.*sqrt(3.*nshi*bb/aa(ii,jj))
-                zdcrit(ii,jj,kk) = 2.*sqrt(3.*ns(ii,jj,kk)*bb/aa(ii,jj))
+                zdcrlo(ii,jj,kk) = 2.*sqrt(3.*nslo*bb/aa)
+                zdcrhi(ii,jj,kk) = 2.*sqrt(3.*nshi*bb/aa)
+                zdcrit(ii,jj,kk) = 2.*sqrt(3.*ns(ii,jj,kk)*bb/aa)
 
              END DO ! kk
 
@@ -315,98 +369,10 @@ CONTAINS
        CALL activate3(kproma,kbdim,klev,paero,bcrita,bcritb,  &
                       zdcrit, zdcrlo, zdcrhi, zdcstar, pactd  )
 
-    END IF ! lsactbase
-
- 
-  END SUBROUTINE cloud_activation
-
-! -----------------------------------------------------------------
-
-  SUBROUTINE getSolute(kproma,kbdim,klev,paero,pns)
-    
-    USE mo_submctl, ONLY : t_section,nlim,       &
-                               in1a,fn1a,            &
-                               in2a,fn2a,            &
-                               in2b,fn2b,            &
-                               rhosu, rhooc, rhobc,  &
-                               rhonh, rhono, rhodu,  &
-                               rhoss,                &
-                               msu, moc, mbc,        &
-                               mnh, mno, mdu,        &
-                               mss
-    IMPLICIT NONE
-
-    INTEGER, INTENT(IN) :: kproma,kbdim,klev
-    TYPE(t_section), INTENT(IN) :: paero(kbdim,klev,fn2b)
-    REAL, INTENT(OUT) :: pns(kbdim,klev,fn2b)
-
-    INTEGER :: ii,jj,kk
-
-    pns = 0.
-
-    DO jj = 1,klev
-
-       DO ii = 1,kproma
-
-          !-- subrange 1a
-
-          !-- calculation of critical superaturation in the middle of the bin
-
-          !-- volume in the middle of the bin
-
-          DO kk = in1a, fn1a
-             IF (paero(ii,jj,kk)%numc > nlim) THEN
-
-                !-- number of moles of solute in one particle [mol]
-                pns(ii,jj,kk) = (3.*paero(ii,jj,kk)%volc(1)*rhosu/msu  +   &
-                     paero(ii,jj,kk)%volc(2)*rhooc/moc)/                      &
-                     paero(ii,jj,kk)%numc
-
-             END IF
-          END DO
-
-          !-- subrange 2a
-
-          DO kk = in2a, fn2a
-             IF (paero(ii,jj,kk)%numc > nlim) THEN
-
-                pns(ii,jj,kk) = (3.*paero(ii,jj,kk)%volc(1)*rhosu/msu  +   &
-                     paero(ii,jj,kk)%volc(2) * rhooc/moc +                    &
-                     paero(ii,jj,kk)%volc(6) * rhono/mno +                    &
-                     paero(ii,jj,kk)%volc(7) * rhonh/mnh +                    &
-                     2.*paero(ii,jj,kk)%volc(5) * rhoss/mss)/              &
-                     paero(ii,jj,kk)%numc
-
-             END IF
-          END DO
-
-          !-- subrange 2b
-
-          DO kk = in2b, fn2b
-             IF (paero(ii,jj,kk)%numc > nlim) THEN
-
-                pns(ii,jj,kk) = (3.*paero(ii,jj,kk)%volc(1)*rhosu/msu  +   &
-                        paero(ii,jj,kk)%volc(2) * rhooc/moc +                 &
-                        paero(ii,jj,kk)%volc(6) * rhono/mno +                 &
-                        paero(ii,jj,kk)%volc(7) * rhonh/mnh +                 &
-                        2.*paero(ii,jj,kk)%volc(5) * rhoss/mss)/           &
-                        paero(ii,jj,kk)%numc
-
-             END IF
-          END DO
+  END SUBROUTINE ActCloudBase
 
 
-
-       END DO
-
-    END DO
-
-
-  END SUBROUTINE getSolute
-
-! -----------------------------------------------------------------
-
-  SUBROUTINE actInterst(kproma,kbdim,klev,paero,pcloud,prv,prs,paa)
+  SUBROUTINE actInterst(kproma,kbdim,klev,paero,pcloud,prv,prs,temp)
     !
     ! Activate interstitial aerosols if they've reached their critical size
     !
@@ -416,24 +382,32 @@ CONTAINS
     ! 2. Based on Dcrit and Dwet slopes, estimate the Ddry where Dwet becomes > Dcrit
     ! 3. Formulate the slopes for number concentration
     ! 4. Use the Dry limits from (2) as the integration limits if they are defined
-
-    
-    USE mo_submctl, ONLY : t_section,nlim,pi6,ica,fca,icb,fcb, &
-                               in1a,fn1a,in2a,fn2a,                &
-                               nbins,ncld
+    !
+    ! Note: insoluble species are not properly accounted for
+    !
+    USE mo_submctl, ONLY :     &
+         rg,                             & ! molar gas constant [J/(mol K)]
+         surfw0,                       & ! surface tension of water [J/m2]
+         t_section,nlim,pi6,         &
+         ica,fca,icb,fcb,             &
+         mwa, rhowa,                &
+         in1a,fn2a,in2b,fn2b,       &
+         nbins,ncld
     IMPLICIT NONE
 
     INTEGER, INTENT(IN) :: kproma,kbdim,klev
     TYPE(t_section), INTENT(INOUT) :: paero(kbdim,klev,nbins),  &
                                       pcloud(kbdim,klev,ncld)
-    REAL, INTENT(IN) :: prv(kbdim,klev),prs(kbdim,klev),    &  ! Water vapour and saturation mixin ratios
-                            paa(kbdim,klev)                        ! Coefficient for Kelvin effect
+    REAL, INTENT(IN) :: prv(kbdim,klev),prs(kbdim,klev)  ! Water vapour and saturation mixin ratios
+    REAL, INTENT(in) :: temp(kbdim,klev)  ! Absolute temperature
+
+    TYPE(t_section) :: pactd(ncld) ! Local variable
+
+    REAL :: paa        ! Coefficient for Kelvin effect
 
     REAL :: zdcstar,zvcstar   ! Critical diameter/volume corresponding to S_LES
-    REAL :: zvcint            ! Integration limit volume based on above
     REAL :: zactvol           ! Total volume of the activated particles
 
-    TYPE(t_section) :: zactd(ncld)   ! Temporary storage for activated particles
     REAL :: Nact, Vact(8)        ! Helper variables for transferring the activated particles
 
     REAL :: Nmid, Nim1, Nip1     ! Bin number concentrations in current and adjacent bins
@@ -446,8 +420,6 @@ CONTAINS
 
     REAL :: Vwmid, Vwim1, Vwip1  ! Wet particle volume in the middle of the bin
     REAL :: Vwlo,Vwhi            ! Wet particle volume at bin edges
-    REAL :: Vwlom1, Vwhim1       ! Wet particle volumes for adjacent bins
-    REAL :: Vwlop1, Vwhip1       ! - '' -
 
     REAL :: zs1,zs2           ! Slopes for number concetration distributions within bins
 
@@ -462,37 +434,44 @@ CONTAINS
 
 
     DO jj = 1,klev
+       DO ii = 1,kbdim
+          IF ( prv(ii,jj)/prs(ii,jj) <= 1.000 ) CYCLE
 
-       DO ii = 1,kproma
+          paa = 4.*mwa*surfw0/(rg*rhowa*temp(ii,jj)) ! Kelvin effect [m]
 
-          IF ( prv(ii,jj)/prs(ii,jj) > 1.000 ) THEN
+          ! Determine Dstar == critical diameter corresponding to the host model S
+          zdcstar = 2.*paa/( 3.*( (prv(ii,jj)/prs(ii,jj))-1. ) )
+          zvcstar = pi6*zdcstar**3
 
-             zactd(1:ncld)%numc = 0.
-             DO ss = 1,8
-                zactd(1:ncld)%volc(ss) = 0.
-             END DO
-
-             ! Determine Dstar == critical diameter corresponding to the host model S
-             zdcstar = 2.*paa(ii,jj)/( 3.*( (prv(ii,jj)/prs(ii,jj))-1. ) )
-             zvcstar = pi6*zdcstar**3
-
-             ! Loop over cloud droplet (and aerosol) bins
-             DO cb = ica%cur, fca%cur
+          ! Loop over cloud droplet (and aerosol) bins
+          DO cb = ica%cur, fcb%cur
+             IF (cb<=fca%cur) THEN
+                ! a-bins
                 ab = ica%par + (cb-ica%cur)
+             ELSE
+                ! b-bins
+                ab = icb%par + (cb-icb%cur)
+             ENDIF
+             pactd(cb)%numc = 0.d0
+             pactd(cb)%volc(:) =0.d0
+             IF ( paero(ii,jj,ab)%numc < nlim) CYCLE
+             intrange = .FALSE.
 
-                IF ( paero(ii,jj,ab)%numc < nlim) CYCLE
+             ! Define some parameters
+             Nmid = paero(ii,jj,ab)%numc     ! Number concentration at the current bin center
+             Vwmid = SUM(paero(ii,jj,ab)%volc(:))/Nmid  ! Wet volume at the current bin center
+             Vmid = SUM(paero(ii,jj,ab)%volc(1:7))/Nmid ! Dry volume at the current bin center
+             Vlo = Vmid*paero(ii,jj,ab)%vratiolo        ! Dry vol at low limit
+             Vhi = Vmid*paero(ii,jj,ab)%vratiohi        ! Dry vol at high limit
 
-                intrange = .FALSE.
-
-                ! Define some parameters
-                Nmid = paero(ii,jj,ab)%numc     ! Number concentration at the current bin center
-                Vwmid = SUM(paero(ii,jj,ab)%volc(:))/Nmid  ! Wet volume at the current bin center
-                Vmid = SUM(paero(ii,jj,ab)%volc(1:7))/Nmid ! Dry volume at the current bin center
-                Vlo = Vmid*paero(ii,jj,ab)%vratiolo        ! Dry vol at low limit
-                Vhi = Vmid*paero(ii,jj,ab)%vratiohi        ! Dry vol at high limit
-
-                ! Number concentrations and volumes at adjacent bins (check for sizedistribution boundaries)
-                IF ( ab > in1a ) THEN
+             ! Number concentrations and volumes at adjacent bins (check for sizedistribution boundaries)
+             IF (ab==in1a .OR. ab==in2b) THEN
+                   Nim1 = nlim
+                   Vim1 = Vlo/2.
+                   Vlom1 = 0.
+                   Vhim1 = Vlo
+                   Vwim1 = Vwmid/3.
+             ELSE
                    Nim1 = paero(ii,jj,ab-1)%numc
                    IF (Nim1 > nlim) THEN
                       Vim1 = SUM(paero(ii,jj,ab-1)%volc(1:7))/Nim1
@@ -503,14 +482,14 @@ CONTAINS
                    END IF
                    Vlom1 = Vim1*paero(ii,jj,ab-1)%vratiolo
                    Vhim1 = Vim1*paero(ii,jj,ab-1)%vratiohi
-                ELSE ! ab == in1a
-                   Nim1 = nlim
-                   Vim1 = Vlo/2.
-                   Vlom1 = 0.
-                   Vhim1 = Vlo
-                   Vwim1 = Vwmid/3. ! Tää ny o vähä tämmöne
-                END IF
-                IF ( ab < fn2a ) THEN
+             END IF
+             IF (ab==fn2a .OR. ab==fn2b ) THEN
+                   Nip1 = nlim
+                   Vip1 = Vhi + 0.5*(Vhi-Vlo)
+                   Vlop1 = Vhi
+                   Vhip1 = Vhi + (Vhi-Vlo)
+                   Vwip1 = Vhip1
+             ELSE
                    Nip1 = paero(ii,jj,ab+1)%numc
                    IF (Nip1 > nlim) THEN
                       Vip1 = SUM(paero(ii,jj,ab+1)%volc(1:7))/Nip1
@@ -521,163 +500,131 @@ CONTAINS
                    END IF
                    Vlop1 = Vip1*paero(ii,jj,ab+1)%vratiolo
                    Vhip1 = Vip1*paero(ii,jj,ab+1)%vratiohi
-                ELSE ! ab == fn2a
-                   Nip1 = nlim
-                   Vip1 = Vhi + 0.5*(Vhi-Vlo)
-                   Vlop1 = Vhi
-                   Vhip1 = Vhi + (Vhi-Vlo)
-                   Vwip1 = Vhip1  ! ....
-                END IF
+             END IF
 
-                ! Keeping thins smooth...
-                Vip1 = MAX(Vhi,Vip1)
-                Vim1 = MIN(Vlo,Vim1)
+             ! Keeping things smooth...
+             Vip1 = MAX(Vhi,Vip1)
+             Vim1 = MIN(Vlo,Vim1)
 
-                ! First, make profiles of particle wet radius in
-                ! order to determine the integration boundaries
-                zs1 = (Vwmid - MAX(Vwim1,0.))/(Vmid - Vim1)
-                zs2 = (MAX(Vwip1,0.) - Vwmid)/(Vip1 - Vmid)
+             ! First, make profiles of particle wet radius in
+             ! order to determine the integration boundaries
+             zs1 = (Vwmid - MAX(Vwim1,0.))/(Vmid - Vim1)
+             zs2 = (MAX(Vwip1,0.) - Vwmid)/(Vip1 - Vmid)
 
-                ! Get the origin values for slope equations
-                V01 = Vwmid - zs1*Vmid
-                V02 = Vwmid - zs2*Vmid
+             ! Get the origin values for slope equations
+             V01 = Vwmid - zs1*Vmid
+             V02 = Vwmid - zs2*Vmid
 
-                ! Get the wet sizes at bins edges
-                Vwlo = MAX(V01 + zs1*Vlo, 0.)
-                Vwhi = MAX(V02 + zs2*Vhi, 0.)
+             ! Get the wet sizes at bins edges
+             Vwlo = MAX(V01 + zs1*Vlo, 0.)
+             Vwhi = MAX(V02 + zs2*Vhi, 0.)
 
-                ! Find out dry vol integration boundaries based on *zvcstar*:
-                IF ( zvcstar < Vwlo .AND. zvcstar < Vwmid .AND. zvcstar < Vwhi ) THEN
-                   ! Whole bin activates
+             ! Find out dry vol integration boundaries based on *zvcstar*:
+             IF ( zvcstar < Vwlo .AND. zvcstar < Vwmid .AND. zvcstar < Vwhi ) THEN
+                ! Whole bin activates
+                vint1 = Vlo
+                vint2 = Vhi
+
+                intrange(1:4) = .TRUE.
+
+             ELSE IF ( zvcstar > Vwlo .AND. zvcstar > Vwmid .AND. zvcstar > Vwhi) THEN
+                ! None activates
+                vint1 = 999.
+                vint2 = 999.
+
+                intrange(1:4) = .FALSE.
+
+             ELSE
+                ! Partial activation:
+                 ! Slope1
+                vcut = (zvcstar - V01)/zs1  ! Where the wet size profile intersects the critical size (slope 1)
+                IF (vcut < Vlo .OR. vcut > Vmid) THEN
+                   ! intersection volume outside the current size range -> set as the lower limit
                    vint1 = Vlo
-                   vint2 = Vhi
-
-                   intrange(1:4) = .TRUE.
-
-                ELSE IF ( zvcstar > Vwlo .AND. zvcstar > Vwmid .AND. zvcstar > Vwhi) THEN
-                   ! None activates
-                   vint1 = 999.
-                   vint2 = 999.
-
-                   intrange(1:4) = .FALSE.
-
                 ELSE
-                   ! Partial activation:
-                   ! Slope1
-                   vcut = (zvcstar - V01)/zs1  ! Where the wet size profile intersects the critical size (slope 1)
-                   IF (vcut < Vlo .OR. vcut > Vmid) THEN
-                      ! intersection volume outside the current size range -> set as the lower limit
-                      vint1 = Vlo
-                   ELSE
-                      vint1 = vcut
-                   END IF
-
-                   ! Slope2
-                   vcut = (zvcstar - V02)/zs2  ! Where the wet size profile intersects the critical size (slope 2)
-                   IF (vcut < Vmid .OR. vcut > Vhi) THEN
-                      ! Intersection volume outside the current size range -> set as the lower limit
-                      vint2 = Vmid
-                   ELSE
-                      vint2 = vcut
-                   END IF
-
-                   ! Determine which size ranges have wet volume larger than the critical
-                   intrange(1) = ( Vwlo > zvcstar )
-                   intrange(2) = ( Vwmid > zvcstar )
-                   intrange(3) = ( Vwmid > zvcstar )
-                   intrange(4) = ( Vwhi > zvcstar )
-
-                END IF
-                ! DONE WITH INTEGRATION LIMITS
-                ! -------------------------------------
-
-                ! Number concentration profiles within bins and integration for number of activated:
-                ! -----------------------------------------------------------------------------------
-                ! get density distribution values for number concentration
-                dNim1 = Nim1/(Vhim1-Vlom1)
-                dNip1 = Nip1/(Vhip1-Vlop1)
-                dNmid = Nmid/(Vhi-Vlo)
-
-                ! Get slopes
-                zs1 = ( dNmid - dNim1 )/( Vmid - Vim1 )
-                zs2 = ( dNip1 - dNmid )/( Vip1 - Vmid )
-
-                N01 = dNmid - zs1*Vmid  ! Origins
-                N02 = dNmid - zs2*Vmid  !
-
-                ! Define normalization factors
-                Nnorm = intgN(zs1,N01,Vlo,Vmid) + intgN(zs2,N02,Vmid,Vhi)
-                Vnorm = intgV(zs1,N01,Vlo,Vmid) + intgV(zs2,N02,Vmid,Vhi)
-
-                ! Accumulated variables
-                zactvol = 0.
-                Nact = 0.
-                Vact(:) = 0.
-
-                ! Integration over each size range within a bin
-                IF ( intrange(1) ) THEN
-                   Nact = Nact + (Nmid/Nnorm)*intgN(zs1,N01,Vlo,vint1)
-                   zactvol = zactvol + (Nmid*Vmid/Vnorm)*intgV(zs1,N01,Vlo,vint1)
+                   vint1 = vcut
                 END IF
 
-                IF ( intrange(2) ) THEN
-                   Nact = Nact + (Nmid/Nnorm)*intgN(zs1,N01,vint1,Vmid)
-                   zactvol = zactvol + (Nmid*Vmid/Vnorm)*intgV(zs1,N01,vint1,Vmid)
+                ! Slope2
+                vcut = (zvcstar - V02)/zs2  ! Where the wet size profile intersects the critical size (slope 2)
+                IF (vcut < Vmid .OR. vcut > Vhi) THEN
+                   ! Intersection volume outside the current size range -> set as the lower limit
+                   vint2 = Vmid
+                ELSE
+                   vint2 = vcut
                 END IF
 
-                IF ( intrange(3) ) THEN
-                   Nact = Nact + (Nmid/Nnorm)*intgN(zs2,N02,Vmid,vint2)
-                   zactvol = zactvol + (Nmid*Vmid/Vnorm)*intgV(zs2,N02,Vmid,vint2)
-                END IF
-
-                IF ( intrange(4) ) THEN
-                   Nact = Nact + (Nmid/Nnorm)*intgN(zs2,N02,vint2,Vhi)
-                   zactvol = zactvol + (Nmid*Vmid/Vnorm)*intgV(zs2,N02,vint2,Vhi)
-                END IF
-
-                DO ss = 1,8
-                   Vact(ss) = zactvol*( paero(ii,jj,ab)%volc(ss)/(Vmid*Nmid) )
-                END DO
-
-                ! Store the number concentration and mass of activated particles for current bins
-                zactd(cb)%numc = MIN(Nact,Nmid)
-                zactd(cb)%volc(:) = MIN(Vact(:),paero(ii,jj,ab)%volc(:))
-                
-
-                IF (zactd(cb)%numc < 0.) THEN
-                   WRITE(*,*) Nim1,Nmid,Nip1
-                   WRITE(*,*) dNim1,dNmid,dNip1
-                   WRITE(*,*) Vim1,Vlo,Vmid,Vhi,Vip1
-                   WRITE(*,*) N01,N02,zs1,zs2
-                   WRITE(*,*) vint1,vint2
-                END IF
-
-             END DO ! cb
-
-             IF (ANY(zactd(:)%numc < 0.)) THEN
-                WRITE(*,*) 'NEGATIVE ACTIVATED'
-                WRITE(*,*) zactd(:)%numc
-                WRITE(*,*) '---------'
-                WRITE(*,*) 'Setting MAX(Nact,0)'
-                zactd(:)%numc = MAX(zactd(:)%numc, 0.)
-                DO ss = 1,8
-                   WHERE(zactd(:)%numc == 0.) zactd(:)%volc(ss) = 0.
-                END DO
+                ! Determine which size ranges have wet volume larger than the critical
+                intrange(1) = ( Vwlo > zvcstar )
+                intrange(2) = ( Vwmid > zvcstar )
+                intrange(3) = ( Vwmid > zvcstar )
+                intrange(4) = ( Vwhi > zvcstar )
 
              END IF
-             
-             ! Apply the number and mass activated to aerosol and cloud bins
-             !WRITE(*,*) zactd(1:7)%numc/paero(ii,jj,4:10)%numc
-             paero(ii,jj,ica%par:fca%par)%numc =   &
-                  MAX(0., paero(ii,jj,ica%par:fca%par)%numc - zactd(ica%cur:fca%cur)%numc)
-             pcloud(ii,jj,ica%cur:fca%cur)%numc = pcloud(ii,jj,ica%cur:fca%cur)%numc + zactd(ica%cur:fca%cur)%numc
+
+             ! Number concentration profiles within bins and integration for number of activated:
+             ! -----------------------------------------------------------------------------------
+             ! get density distribution values for number concentration
+             dNim1 = Nim1/(Vhim1-Vlom1)
+             dNip1 = Nip1/(Vhip1-Vlop1)
+             dNmid = Nmid/(Vhi-Vlo)
+
+             ! Get slopes
+             zs1 = ( dNmid - dNim1 )/( Vmid - Vim1 )
+             zs2 = ( dNip1 - dNmid )/( Vip1 - Vmid )
+
+             N01 = dNmid - zs1*Vmid  ! Origins
+             N02 = dNmid - zs2*Vmid  !
+
+             ! Define normalization factors
+             Nnorm = intgN(zs1,N01,Vlo,Vmid) + intgN(zs2,N02,Vmid,Vhi)
+             Vnorm = intgV(zs1,N01,Vlo,Vmid) + intgV(zs2,N02,Vmid,Vhi)
+
+             ! Accumulated variables
+             zactvol = 0.
+             Nact = 0.
+             Vact(:) = 0.
+
+             ! Integration over each size range within a bin
+             IF ( intrange(1) ) THEN
+                Nact = Nact + (Nmid/Nnorm)*intgN(zs1,N01,Vlo,vint1)
+                zactvol = zactvol + (Nmid*Vmid/Vnorm)*intgV(zs1,N01,Vlo,vint1)
+             END IF
+
+             IF ( intrange(2) ) THEN
+                Nact = Nact + (Nmid/Nnorm)*intgN(zs1,N01,vint1,Vmid)
+                zactvol = zactvol + (Nmid*Vmid/Vnorm)*intgV(zs1,N01,vint1,Vmid)
+             END IF
+
+             IF ( intrange(3) ) THEN
+                Nact = Nact + (Nmid/Nnorm)*intgN(zs2,N02,Vmid,vint2)
+                zactvol = zactvol + (Nmid*Vmid/Vnorm)*intgV(zs2,N02,Vmid,vint2)
+             END IF
+
+             IF ( intrange(4) ) THEN
+                Nact = Nact + (Nmid/Nnorm)*intgN(zs2,N02,vint2,Vhi)
+                zactvol = zactvol + (Nmid*Vmid/Vnorm)*intgV(zs2,N02,vint2,Vhi)
+             END IF
+
              DO ss = 1,8
-                paero(ii,jj,ica%par:fca%par)%volc(ss) =  &
-                     MAX(0., paero(ii,jj,ica%par:fca%par)%volc(ss) - zactd(ica%cur:fca%cur)%volc(ss))
-                pcloud(ii,jj,ica%cur:fca%cur)%volc(ss) = pcloud(ii,jj,ica%cur:fca%cur)%volc(ss) + zactd(ica%cur:fca%cur)%volc(ss)
+                Vact(ss) = zactvol*( paero(ii,jj,ab)%volc(ss)/(Vmid*Nmid) )
              END DO
-             
-          END IF ! RH limit
+
+             ! Store the number concentration and mass of activated particles for current bins
+             pactd(cb)%numc = MIN(Nact,Nmid)
+             pactd(cb)%volc(:) = MIN(Vact(:),paero(ii,jj,ab)%volc(:))
+
+          END DO ! cb
+
+          ! Apply the number and mass activated to aerosol and cloud bins
+          paero(ii,jj,ica%par:fcb%par)%numc =   &
+               MAX(0., paero(ii,jj,ica%par:fcb%par)%numc - pactd(ica%cur:fcb%cur)%numc)
+          pcloud(ii,jj,ica%cur:fcb%cur)%numc = pcloud(ii,jj,ica%cur:fcb%cur)%numc + pactd(ica%cur:fcb%cur)%numc
+          DO ss = 1,8
+             paero(ii,jj,ica%par:fcb%par)%volc(ss) =  &
+               MAX(0., paero(ii,jj,ica%par:fcb%par)%volc(ss) - pactd(ica%cur:fcb%cur)%volc(ss))
+             pcloud(ii,jj,ica%cur:fcb%cur)%volc(ss) = pcloud(ii,jj,ica%cur:fcb%cur)%volc(ss) + pactd(ica%cur:fcb%cur)%volc(ss)
+          END DO
 
        END DO ! ii
 
@@ -692,10 +639,9 @@ CONTAINS
                        pdcrit, pdcrlo, pdcrhi, pdcstar, pactd   )
     !
     ! Gets the number and mass activated in the critical aerosol size bin
-
-    
-    USE mo_submctl, ONLY : t_parallelbin, t_section, pi6, nlim, fn2b, ncld,  &
-                               in1a,in2a,fn1a,fn2a, ica,fca,icb,fcb
+    !
+    USE mo_submctl, ONLY : t_section, pi6, nlim, fn2b, ncld,  &
+                               in1a,fn2a, ica, fca, icb, fcb, in2b, fn2b
     IMPLICIT NONE
 
     INTEGER, INTENT(IN) :: kproma,kbdim,klev
@@ -720,16 +666,15 @@ CONTAINS
     REAL :: zactvol
 
     REAL :: zhlp
-    REAL :: zratio
 
     INTEGER :: ii,jj,ss,cb,ab
 
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
 
           ! This means in practice that vertical velocity is <= 0 or Ntot == 0
           IF ( ALL(pdcrit(ii,jj,:) < epsilon(1.0)) ) CYCLE
-          
+
           zvcstar = 0.
 
           IF ( paero(ii,jj,pbcrita(ii,jj))%numc < nlim ) THEN
@@ -758,8 +703,12 @@ CONTAINS
           zvcstar = MIN( zvcstar, paero(ii,jj,pbcrita(ii,jj))%vhilim ) 
 
           ! Loop over cloud droplet (and aerosol) bins
-          DO cb = ica%cur,fca%cur
-             ab = ica%par + (cb-ica%cur)
+          DO cb = ica%cur,fcb%cur
+             IF (cb<=fca%cur) THEN
+                ab = ica%par + (cb-ica%cur)
+             ELSE
+                ab = icb%par + (cb-icb%cur)
+             ENDIF
 
              IF ( paero(ii,jj,ab)%numc < nlim) CYCLE
 
@@ -771,7 +720,12 @@ CONTAINS
              Vlo = paero(ii,jj,ab)%vlolim      ! Mid dry volume scaled to bin low limit (this is mostly an educated guess... )
              Vhi = paero(ii,jj,ab)%vhilim      ! Same for high limit
 
-             IF ( ab > in1a ) THEN
+             IF (ab==in1a .OR. ab==in2b) THEN
+                Nim1 = nlim
+                Vim1 = Vlo/2.
+                Vlom1 = 0.
+                Vhim1 = Vlo
+             ELSE
                 Nim1 = MAX(paero(ii,jj,ab-1)%numc, nlim)
                 IF (Nim1 > nlim) THEN
                    Vim1 = SUM(paero(ii,jj,ab-1)%volc(1:7))/Nim1
@@ -780,14 +734,13 @@ CONTAINS
                 END IF
                 Vlom1 = paero(ii,jj,ab-1)%vlolim
                 Vhim1 = paero(ii,jj,ab-1)%vhilim
-             ELSE ! ab == in1a
-                Nim1 = nlim
-                Vim1 = Vlo/2.
-                Vlom1 = 0.
-                Vhim1 = Vlo
              END IF
-
-             IF ( ab < fn2a ) THEN
+             IF (ab==fn2a .OR. ab==fn2b) THEN
+                Nip1 = nlim
+                Vip1 = Vhi + 0.5*(Vhi-Vlo)
+                Vlop1 = Vhi
+                Vhip1 = Vhi + (Vhi-Vlo)
+             ELSE
                 Nip1 = MAX(paero(ii,jj,ab+1)%numc, nlim)
                 IF (Nip1 > nlim) THEN
                    Vip1 = SUM(paero(ii,jj,ab+1)%volc(1:7))/Nip1
@@ -796,11 +749,6 @@ CONTAINS
                 END IF
                 Vlop1 = paero(ii,jj,ab+1)%vlolim
                 Vhip1 = paero(ii,jj,ab+1)%vhilim
-             ELSE ! ab == fn2a
-                Nip1 = nlim
-                Vip1 = Vhi + 0.5*(Vhi-Vlo)
-                Vlop1 = Vhi
-                Vhip1 = Vhi + (Vhi-Vlo)
              END IF
 
              Vip1 = MAX(Vlop1,MIN(Vip1,Vhip1))
@@ -848,16 +796,6 @@ CONTAINS
 
              END IF
 
-             !IF ( pactd(ii,jj,cb)%numc < 0. .OR. ANY(pactd(ii,jj,cb)%volc(:) < 0.) ) WRITE(*,*) 'HEPHEPHPE'
-             IF ( pactd(ii,jj,cb)%numc < -1.e-10 ) THEN
-                WRITE(*,*) 'activate3: negative numc, ',pactd(ii,jj,cb)%numc, ab
-                WRITE(*,*) dNim1,dNip1,dNmid
-                WRITE(*,*) Nnorm,Vnorm
-                WRITE(*,*) Vip1, Vhip1,Vlop1
-                WRITE(*,*) Vlo,Vhi,Vmid,zvcint
-                WRITE(*,*) zs1,zs2,N01,N02
-             END IF
-
              pactd(ii,jj,cb)%numc = MAX(0., pactd(ii,jj,cb)%numc)
              DO ss = 1,8
                 pactd(ii,jj,cb)%volc(ss) = MAX(0., pactd(ii,jj,cb)%volc(ss))
@@ -893,6 +831,7 @@ CONTAINS
     intgV = (1./3.)*ikk*MAX(ihigh**3 - ilow**3,0.) + 0.5*icc*MAX(ihigh**2 - ilow**2,0.)
   END FUNCTION intgV
 
+
   !-----------------------------------------
   SUBROUTINE autoconv2(kproma,kbdim,klev,   &
                       pcloud,pprecp         )
@@ -907,8 +846,7 @@ CONTAINS
                                nprc,        &
                                rhowa,       &
                                pi6,         &
-                               nlim
-    USE mo_constants, ONLY : rd
+                               nlim, prlim
     IMPLICIT NONE
 
     INTEGER, INTENT(in) :: kproma,kbdim,klev
@@ -926,40 +864,24 @@ CONTAINS
     ! Find the cloud bins where the mean droplet diameter is above 50 um
     ! Do some fitting...
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
           DO cc = 1,ncld
-
-             Vrem = 0.
-             Nrem = 0.
-             Ntot = 0.
-             Vtot = 0.
-             dvg = 0.
-             dg = 0.
 
              Ntot = pcloud(ii,jj,cc)%numc
              Vtot = SUM(pcloud(ii,jj,cc)%volc(:))
 
-             IF ( Ntot > 0. .AND. Vtot > 0. ) THEN
+             IF ( Ntot > nlim .AND. Vtot > 0. ) THEN
 
                 ! Volume geometric mean diameter
                 dvg = ((Vtot/Ntot/pi6)**(1./3.))*EXP( (3.*LOG(sigmag)**2)/2. )
                 dg = dvg*EXP( -3.*LOG(sigmag)**2 )
 
-                !testi = cumlognorm(2.19e-4,sigmag,zd0)
-
                 Vrem = Vtot*( 1. - cumlognorm(dvg,sigmag,zd0) )
                 Nrem = Ntot*( 1. - cumlognorm(dg,sigmag,zd0) )
 
+                IF ( Vrem > 0. .AND. Nrem > prlim) THEN
 
-
-                IF ( Vrem < 0. ) WRITE(*,*) 'ERROR Vrem < 0', Vrem, Vtot
-                IF ( Vrem > Vtot ) WRITE(*,*) 'ERROR Vrem > Vtot', cumlognorm(dvg,sigmag,zd0),dvg,dg,Vtot
-                IF ( Nrem < 0. ) WRITE(*,*) 'ERROR Nrem < 0', Nrem
-                IF ( Nrem > Ntot ) WRITE(*,*) 'ERROR Nrem > Ntot', cumlognorm(dg,sigmag,zd0),dvg,dg,Ntot
-
-                IF ( Vrem > 0. .AND. Nrem > 0.) THEN
-
-                   ! Put the mass and number to the first precipitation bin and remover from
+                   ! Put the mass and number to the first precipitation bin and remove from
                    ! cloud droplets
                    DO ss = 1,7
                       pprecp(ii,jj,1)%volc(ss) = pprecp(ii,jj,1)%volc(ss) + pcloud(ii,jj,cc)%volc(ss)*(Nrem/Ntot)
@@ -992,25 +914,18 @@ CONTAINS
 
   SUBROUTINE ice_het_nucl(kproma,kbdim,klev,   &
                       pcloud,pice,paero,ppres, &
-                      ptemp,prv,prs,ptstep ) 
-
-
+                      ptemp,prv,prs,ptstep )
 
     
     USE mo_submctl, ONLY : t_section,   &
-                               in2b,fn2b,   &
-                               ica,fca,     &
-                               icb,fcb,     &
+                               fn2b,   &
                                ncld,        &
-                               iia,fia,     &
-                               iib,fib,     &
                                nice,        &
                                rhowa,       &
                                rhoic,       &
                                planck,      &
-                               pi6,         &
                                pi,          &
-                               nlim, prlim,eps, debug
+                               nlim, prlim
     USE mo_constants, ONLY : rd, alf, avo
 
     IMPLICIT NONE
@@ -1026,56 +941,70 @@ CONTAINS
                                       pice(kbdim,klev,nice),  &
                                       paero(kbdim,klev,fn2b)
 
-    REAL, PARAMETER :: zd00 = 30.e-6,  &  ! Drizzle onset mean diameter
-                           zd0 = 50.e-6,   &  ! Initial drizzle droplet diameter
-                           ze1 = 2.47,     &
-                           ze2 = -1.79,    &
-                           mult = 1.e-3
-    REAL :: dmixr,   &  ! Change in cloud droplet mixing ratio
-                cmixr,   &  ! Current mixing ratio
-                dnumb,   &  ! Change in droplet number concentration
-                frvol       ! Fractional change in volume concentration
-
     INTEGER :: ii,jj,kk,ss
-    INTEGER :: hh
     REAL :: phf = 0., & ! probability of homogeneous freezing of a wet aerosol particle
                 rn, & !radius of the insoluble portion of the aerosol
                 rdry,qv,jcf
-    LOGICAL :: freez
-    REAL :: Vrem, Nrem, Vtot, Ntot, frac
+    REAL :: Vtot, Ntot, frac
 
-    DO kk = in2b, fn2b ! insoluble materials !1,nice
-       DO ii = 1,kproma
+    DO ii = 1,kbdim
+        DO jj = 1,klev
+            if (ptemp(ii,jj) > 243. ) cycle
 
-          DO jj = 1,klev
+            ! Cloud droplets => ice
+            DO kk = 1,ncld
+              IF (pcloud(ii,jj,kk)%numc<nlim) CYCLE
 
-              rdry = (3.*sum(paero(ii,jj,kk)%volc) /paero(ii,jj,kk)%numc/4./pi)**(1./3.) !! dry radius of particle  !!huomhuom pcloud vai paero
-              qv = (1.-sum( paero(ii,jj,kk)%volc(3:4) ))/(1. - sum(paero(ii,jj,kk)%volc(1:7))) !!! the volume soluble fraction of the aerosol huomhuom tarkista tämän laskeminen
-              rn = rdry*(1-qv)**(1./3.)
+              rdry = (3.*sum(pcloud(ii,jj,kk)%volc) /pcloud(ii,jj,kk)%numc/4./pi)**(1./3.)
+              qv = (1.-sum( pcloud(ii,jj,kk)%volc(3:4) ))/(1. - sum(pcloud(ii,jj,kk)%volc(1:7))) ! Not correct?
+              rn = rdry*(1.-qv)**(1./3.)  ! Not correct?
               jcf = calc_JCF( rn,ptemp(ii,jj), ppres(ii,jj), prv(ii,jj), prs(ii,jj) )
-              phf = 1 - exp( -jcf*ptstep )
-
+              phf = 1. - exp( -jcf*ptstep )
               Ntot = pcloud(ii,jj,kk)%numc
               Vtot = SUM(pcloud(ii,jj,kk)%volc(:))
 
-!              if ( phf> 0. ) write (*,*) 'phf ',phf , ' debugkebab'
+              frac = MIN(1.,phf)
+              IF (pcloud(ii,jj,kk)%numc*frac <prlim) CYCLE
+  
+              DO ss = 1,7
+                   pice(ii,jj,kk)%volc(ss) = max(0.,pice(ii,jj,kk)%volc(ss) + pcloud(ii,jj,kk)%volc(ss)*frac)
+                   pcloud(ii,jj,kk)%volc(ss) = max(0.,pcloud(ii,jj,kk)%volc(ss) - pcloud(ii,jj,kk)%volc(ss)*frac)
+              END DO
+              ss=8
+              pice(ii,jj,kk)%volc(ss) = max(0.,pice(ii,jj,kk)%volc(ss) + pcloud(ii,jj,kk)%volc(ss)*frac*rhowa/rhoic)
+              pcloud(ii,jj,kk)%volc(ss) = max(0.,pcloud(ii,jj,kk)%volc(ss) - pcloud(ii,jj,kk)%volc(ss)*frac)
 
-              frac = MAX(0.,MIN(1.,phf))
+              pice(ii,jj,kk)%numc = max(0.,pice(ii,jj,kk)%numc + pcloud(ii,jj,kk)%numc*frac)
+              pcloud(ii,jj,kk)%numc = max(0.,pcloud(ii,jj,kk)%numc-pcloud(ii,jj,kk)%numc*frac)
+            END DO
 
-              DO ss = 1,8
-                      pice(ii,jj,kk)%volc(ss) = max(0., pice(ii,jj,kk)%volc(ss) + &
-                                                           pcloud(ii,jj,kk)%volc(ss)*frac)
+            ! Aerosol => ice
+            DO kk = 1, fn2b
+              IF (paero(ii,jj,kk)%numc<nlim) CYCLE
 
-                      pcloud(ii,jj,kk)%volc(ss) = max(0., pcloud(ii,jj,kk)%volc(ss)*(1. - frac))
-               END DO
+              rdry = (3.*sum(paero(ii,jj,kk)%volc) /paero(ii,jj,kk)%numc/4./pi)**(1./3.)
+              qv = (1.-sum( paero(ii,jj,kk)%volc(3:4) ))/(1. - sum(paero(ii,jj,kk)%volc(1:7))) ! Not correct?
+              rn = rdry*(1.-qv)**(1./3.)  ! Not correct?
+              jcf = calc_JCF( rn,ptemp(ii,jj), ppres(ii,jj), prv(ii,jj), prs(ii,jj) )
+              phf = 1. - exp( -jcf*ptstep )
+              Ntot = paero(ii,jj,kk)%numc
+              Vtot = SUM(paero(ii,jj,kk)%volc(:))
+              frac = MIN(1.,phf)
+              IF (paero(ii,jj,kk)%numc*frac <prlim) CYCLE
+  
+              DO ss = 1,7
+                   pice(ii,jj,kk)%volc(ss) = max(0.,pice(ii,jj,kk)%volc(ss) + paero(ii,jj,kk)%volc(ss)*frac)
+                   paero(ii,jj,kk)%volc(ss) = max(0.,paero(ii,jj,kk)%volc(ss) - paero(ii,jj,kk)%volc(ss)*frac)
+              END DO
+              ss=8
+              pice(ii,jj,kk)%volc(ss) = max(0.,pice(ii,jj,kk)%volc(ss) + paero(ii,jj,kk)%volc(ss)*frac*rhowa/rhoic)
+              paero(ii,jj,kk)%volc(ss) = max(0.,paero(ii,jj,kk)%volc(ss) - paero(ii,jj,kk)%volc(ss)*frac)
 
-               pice(ii,jj,kk)%numc = max( 0., pice(ii,jj,kk)%numc + pcloud(ii,jj,kk)%numc*frac )
-               pcloud(ii,jj,kk)%numc = max(0., pcloud(ii,jj,kk)%numc*(1. - frac) )
-
-          END DO
+              pice(ii,jj,kk)%numc = max(0.,pice(ii,jj,kk)%numc + paero(ii,jj,kk)%numc*frac)
+              paero(ii,jj,kk)%numc = max(0.,paero(ii,jj,kk)%numc-paero(ii,jj,kk)%numc*frac)
+            END DO
        END DO
     END DO
-
 
   END SUBROUTINE ice_het_nucl
   !***********************************************
@@ -1088,21 +1017,15 @@ CONTAINS
                       pcloud,pice,paero,ppres, &
                       ptemp,prv,prs,ptstep ) 
 
-    
     USE mo_submctl, ONLY : t_section,   &
-                               in2b,fn2b,   &
-                               ica,fca,     &
-                               icb,fcb,     &
                                ncld,        &
-                               iia,fia,     &
-                               iib,fib,     &
                                nice,        &
+                               fn2b,        &
                                rhowa,       &
                                rhoic,       &
-                               planck,      &
                                pi6,         &
                                pi,          &
-                               nlim, prlim,eps
+                               nlim, prlim
     USE mo_constants, ONLY : rd, alf, avo
 
     IMPLICIT NONE
@@ -1118,70 +1041,66 @@ CONTAINS
                                       pice(kbdim,klev,nice),  &
                                       paero(kbdim,klev,fn2b)
 
-    REAL, PARAMETER :: zd00 = 30.e-6,  &  ! Drizzle onset mean diameter
-                           zd0 = 50.e-6,   &  ! Initial drizzle droplet diameter
-                           ze1 = 2.47,     &
-                           ze2 = -1.79,    &
-                           mult = 1.e-3
-    REAL :: dmixr,   &  ! Change in cloud droplet mixing ratio
-                cmixr,   &  ! Current mixing ratio
-                dnumb,   &  ! Change in droplet number concentration
-                frvol       ! Fractional change in volume concentration
-
-
     INTEGER :: ii,jj,kk,ss
-    INTEGER :: hh
-    REAL :: phf = 0., & ! probability of homogeneous freezing of a wet aerosol particle
-                rn, & !radius of the insoluble portion of the aerosol
-                rdry, qv,rw,NL,jhf
-    LOGICAL :: freez
-    REAL :: Vrem, Nrem, Vtot, Ntot,frac
+    REAL :: phf,jhf, & ! probability of homogeneous freezing of a wet aerosol particle
+                rn, rw          ! Cube of the insoluble and wet radius
 
+    REAL :: frac
 
-    DO kk = 1,nice
-       DO ii = 1,kproma
+    DO ii = 1,kbdim
+        DO jj = 1,klev
+            if (ptemp(ii,jj) > 243. ) cycle
 
-          DO jj = 1,klev
+            ! Aerosols
+            DO kk = 1,fn2b
+              IF (paero(ii,jj,kk)%numc<nlim) CYCLE
 
-              rdry = (3.*sum(paero(ii,jj,kk)%volc(1:7)) /paero(ii,jj,kk)%numc/4./pi)**(1./3.)
-              qv = (1.-sum(paero(ii,jj,kk)%volc(3:4)))/(1. - sum(paero(ii,jj,kk)%volc(1:7))) !!! the volume soluble fraction of the aerosol huomhuom tarkista tämän laskeminen #arvo
-              rn = rdry*(1-qv)**(1./3.) !! radius of the insoluble portion of particle
-              rw = paero(ii,jj,kk)%dwet  ! #arvo
-              NL = paero(ii,jj,kk)%numc !! #arvo
-              if (ptemp(ii,jj) > 243 ) cycle
-              jhf = calc_JHF( NL , ptemp(ii,jj))
-              phf = 1 - exp( -jhf*pi6*( rw**3 - rn**3 )*ptstep)
-!              if (phf > 0.)  write(*,*) 'phf ', phf, ' homogenous debugkebab'
-              Ntot = paero(ii,jj,kk)%numc
-              Vtot = SUM(paero(ii,jj,kk)%volc(:))
+              rn = (3.*sum(paero(ii,jj,kk)%volc(3:7)) /paero(ii,jj,kk)%numc/4./pi)
+              rw = paero(ii,jj,kk)%dwet**3.
+              jhf = calc_JHF( paero(ii,jj,kk)%numc , ptemp(ii,jj))
+              phf = 1. - exp( -jhf*pi6*( rw - rn )*ptstep)
 
-              frac = MAX(0.,MIN(1.,phf))
+              frac = MIN(1.,phf)
+              IF (paero(ii,jj,kk)%numc*frac <prlim) CYCLE
 
-              DO ss = 1,8
-                      pice(ii,jj,kk)%volc(ss) = max(0., pice(ii,jj,kk)%volc(ss) + &
-                                                           pcloud(ii,jj,kk)%volc(ss)*frac)
-
-                      pcloud(ii,jj,kk)%volc(ss) = max(0., pcloud(ii,jj,kk)%volc(ss)*(1. - frac))
+              DO ss = 1,7
+                   pice(ii,jj,kk)%volc(ss) = max(0.,pice(ii,jj,kk)%volc(ss) + paero(ii,jj,kk)%volc(ss)*frac)
+                   paero(ii,jj,kk)%volc(ss) = max(0.,paero(ii,jj,kk)%volc(ss)*(1. - frac))
                END DO
+               ss=8  ! Water
+               pice(ii,jj,kk)%volc(ss) = max(0.,pice(ii,jj,kk)%volc(ss) + paero(ii,jj,kk)%volc(ss)*frac*rhowa/rhoic)
+               paero(ii,jj,kk)%volc(ss) = max(0.,paero(ii,jj,kk)%volc(ss)*(1. - frac))
 
-               pice(ii,jj,kk)%numc = max( 0., pice(ii,jj,kk)%numc + pcloud(ii,jj,kk)%numc*frac )
-               pcloud(ii,jj,kk)%numc = max(0., pcloud(ii,jj,kk)%numc*(1. - frac) )
+               pice(ii,jj,kk)%numc = max( 0.,pice(ii,jj,kk)%numc + paero(ii,jj,kk)%numc*frac)
+               paero(ii,jj,kk)%numc = max(0.,paero(ii,jj,kk)%numc*(1. - frac))
+            END DO
 
+            ! Cloud droplets
+            DO kk = 1,ncld
+              IF (pcloud(ii,jj,kk)%numc<nlim) CYCLE
 
-              DO ss = 1,8
-                      pice(ii,jj,kk)%volc(ss) = max(0., pice(ii,jj,kk)%volc(ss) + &
-                                                           paero(ii,jj,kk)%volc(ss)*frac)
+              rn = (3.*sum(pcloud(ii,jj,kk)%volc(3:7)) /pcloud(ii,jj,kk)%numc/4./pi)
+              rw = pcloud(ii,jj,kk)%dwet**3.
+              jhf = calc_JHF( pcloud(ii,jj,kk)%numc , ptemp(ii,jj))
+              phf = 1. - exp( -jhf*pi6*( rw - rn )*ptstep)
 
-                      paero(ii,jj,kk)%volc(ss) = max(0., paero(ii,jj,kk)%volc(ss)*(1. - frac))
+              frac = MIN(1.,phf)
+              IF (pcloud(ii,jj,kk)%numc*frac <prlim) CYCLE
+
+              DO ss = 1,7
+                   pice(ii,jj,kk)%volc(ss) = max(0.,pice(ii,jj,kk)%volc(ss) + pcloud(ii,jj,kk)%volc(ss)*frac)
+                   pcloud(ii,jj,kk)%volc(ss) = max(0.,pcloud(ii,jj,kk)%volc(ss)*(1. - frac))
                END DO
+               ss=8 ! Water
+               pice(ii,jj,kk)%volc(ss) = max(0.,pice(ii,jj,kk)%volc(ss) + pcloud(ii,jj,kk)%volc(ss)*frac*rhowa/rhoic)
+               pcloud(ii,jj,kk)%volc(ss) = max(0.,pcloud(ii,jj,kk)%volc(ss)*(1. - frac))
 
-               pice(ii,jj,kk)%numc = max( 0., pice(ii,jj,kk)%numc + paero(ii,jj,kk)%numc*frac )
-               paero(ii,jj,kk)%numc = max(0., paero(ii,jj,kk)%numc*(1. - frac) )
+               pice(ii,jj,kk)%numc = max( 0.,pice(ii,jj,kk)%numc + pcloud(ii,jj,kk)%numc*frac)
+               pcloud(ii,jj,kk)%numc = max(0.,pcloud(ii,jj,kk)%numc*(1. - frac))
+            END DO
 
-          END DO
-       END DO
+        END DO
     END DO
-
 
   END SUBROUTINE ice_hom_nucl
 
@@ -1195,22 +1114,14 @@ CONTAINS
                       pcloud,pice,ppres, &
                       ptemp,ptt,prv,prs,ptstep, time )
 
-
-
-    
     USE mo_submctl, ONLY : t_section,   &
-                               ica,fca,     &
-                               icb,fcb,     &
                                ncld,        &
-                               iia,fia,     &
-                               iib,fib,     &
                                nice,        &
                                rhowa,       &
                                rhoic,       &
                                planck,      &
-                               pi6,         &
                                pi,          &
-                               nlim, prlim,eps, &
+                               nlim, prlim, &
                                debug
     USE mo_constants, ONLY : rd, alf, avo
 
@@ -1227,80 +1138,43 @@ CONTAINS
     TYPE(t_section), INTENT(inout) :: pcloud(kbdim,klev,ncld), &
                                       pice(kbdim,klev,nice)
 
-    REAL, PARAMETER :: zd00 = 30.e-6,  &  ! Drizzle onset mean diameter
-                           zd0 = 50.e-6,   &  ! Initial drizzle droplet diameter
-                           ze1 = 2.47,     &
-                           ze2 = -1.79,    &
-                           mult = 1.e-3
-    REAL :: dmixr,   &  ! Change in cloud droplet mixing ratio
-                cmixr,   &  ! Current mixing ratio
-                dnumb,   &  ! Change in droplet number concentration
-                frvol       ! Fractional change in volume concentration
-
-
     INTEGER :: ii,jj,kk,ss
-    INTEGER :: hh
-    REAL :: frac_numc = 0., & ! probability of homogeneous freezing of a wet aerosol particle
-                frac_volc = 0., &
-                frac,              &
+    REAL :: frac,              &
                 Ts
-    LOGICAL :: freez
-    REAL :: Vrem, Nrem, Vtot, Ntot, &
+    REAL :: Vtot, Ntot, &
                 a_kiehl, B_kiehl, nucl_rate, &
                 Nicetot, Vicetot, Vinsolub,Temp_tend
 
-      B_kiehl=1.0e-6
-      a_kiehl=1.0
-open(23, file="immersoitu", position='append')
-    DO kk =1,nice  ! insoluble materials !
-       DO ii = 1,kproma
+    B_kiehl=1.0e-6
+    a_kiehl=1.0
 
-          DO jj = 1,klev
+    DO ii = 1,kbdim
+       DO jj = 1,klev
+          ! Decreasing & sub-zero temperatures required
+          if (ptt(ii,jj) > 0. .OR. ptemp(ii,jj)>273.15) cycle
+  
+          Ts = 273.15-ptemp(ii,jj)
+          Temp_tend = ptt(ii,jj)
+
+          DO kk =1,nice
+              IF (pcloud(ii,jj,kk)%numc<nlim) CYCLE
 
               Ntot = pcloud(ii,jj,kk)%numc
               Vtot = SUM(pcloud(ii,jj,kk)%volc(:))
-              write(23,'(A12,A3,I3,A5,F5.1, 3(A5,ES9.1E3))') &
-              'tulostusta','kk', kk, 'aika',time, 'Vtot',Vtot,'Ntot',Ntot, 'dwet', pcloud(ii,jj,kk)%dwet
               Vinsolub = SUM(pcloud(ii,jj,kk)%volc(3:4))
 
               Nicetot = pice(ii,jj,kk)%numc
               Vicetot = SUM(pice(ii,jj,kk)%volc(:))
 
-              Ts = 273.15-ptemp(ii,jj)
-              Temp_tend = ptt(ii,jj)
-              if (Temp_tend > 0. .and. abs(Ntot)<eps .and.  Vinsolub < eps)  then
-                    write(23,*) 'temp_0_N_0_insolub_0', time
-              elseif(Temp_tend > 0. .and. abs(Ntot)<eps .and.  Vinsolub > eps) then
-                    write(23,*) 'temp_0_N_0_insolub_1', time
-              elseif(Temp_tend > 0. .and. abs(Ntot)>eps .and.  Vinsolub < eps) then
-                    write(23,*) 'temp_0_N_1_insolub_0', time
-              elseif(Temp_tend > 0. .and. abs(Ntot)>eps .and.  Vinsolub > eps) then
-                    write(23,*) 'temp_0_N_1_insolub_1', time, Temp_tend
-              elseif(Temp_tend < 0. .and. abs(Ntot)<eps .and.  Vinsolub < eps) then
-                    write(23,*) 'temp_1_N_0_insolub_0', time, Temp_tend
-              elseif(Temp_tend < 0. .and. abs(Ntot)<eps .and.  Vinsolub > eps) then
-                    write(23,*) 'temp_1_N_0_insolub_1', time, Temp_tend
-              elseif(Temp_tend < 0. .and. abs(Ntot)>eps .and.  Vinsolub < eps) then
-                    write(23,*) 'temp_1_N_1_insolub_0', time, Temp_tend
-              elseif(Temp_tend < 0. .and. abs(Ntot)>eps .and.  Vinsolub > eps) then
-                    write(23,'(A25,A5,F7.1, A5, I3, 9(A15,ES10.1E3))') 'temp_1_N_1_insolub_1', &
-                    'aika',time,'bini', kk,&
-                    'tend', Temp_tend,              'Ntot', Ntot,           'Nicetot', Nicetot,&
-                    'Vtot', Vtot,                   'Vinsolub', Vinsolub,   'Vtot/Ntot', Vtot/Ntot, &
-                    'Vinsolub/Vtot', Vinsolub/Vtot, 'dwet cloud', pcloud(ii,jj,kk)%dwet,&
-                    'dwet ice', pice(ii,jj,kk)%dwet
-              end if
-
-
-              if (Temp_tend > 0. .or. abs(Ntot)<eps .or.  Vinsolub < eps) cycle
-
-              if (Temp_tend > 0. .or. abs(Ntot)<eps .or.  Vinsolub < eps) cycle
-!              write(*,*) 'nyt vois tulla jääpilvee debugkebab'
               nucl_rate = Vtot*(-a_kiehl)*B_kiehl*exp(a_kiehl*Ts)*Temp_tend*ptstep
 
-              frac = (nucl_rate+Nicetot)/max(eps,Ntot)
+              ! Incorrect?
+              frac = MIN(1., (nucl_rate+Nicetot)/Ntot )
 
-              frac = MAX(0.,MIN(1.,frac))
+              ! Correct?
+              frac = MIN(1., nucl_rate/Ntot )
+
+              IF (pcloud(ii,jj,kk)%numc*frac < prlim) CYCLE
 
               DO ss = 1,8
                       pice(ii,jj,kk)%volc(ss) = max(0., pice(ii,jj,kk)%volc(ss) + &
@@ -1312,13 +1186,9 @@ open(23, file="immersoitu", position='append')
                pice(ii,jj,kk)%numc = max( 0., pice(ii,jj,kk)%numc + pcloud(ii,jj,kk)%numc*frac )
                pcloud(ii,jj,kk)%numc = max(0., pcloud(ii,jj,kk)%numc*(1. - frac) )
 
-               if(pice(ii,jj,kk)%numc-Nicetot>0.0) write(23,*) 'jäätä', pice(ii,jj,kk)%numc-Nicetot, frac, Ts, Temp_tend
-
           END DO
        END DO
     END DO
-close(23)
-
 
   END SUBROUTINE ice_immers_nucl
 
@@ -1333,7 +1203,7 @@ close(23)
         REAL :: c_1s, psi
         psi = 1.
         c_1s = 1.e19 !! 10**15 cm^-2 !! concentration of water molecules adsorbed on 1 cm^-2 of surface
-        calc_JCF= boltz*temp/planck*psi*c_1s*4.*pi*rn**2.*&
+        calc_JCF= boltz*temp/planck*psi*c_1s*4.*pi*rn**2*&
                   exp((-calc_act_energy(temp,'het')-calc_crit_energy(rn,prv,prs,temp))/(boltz*temp))
 
   END FUNCTION calc_JCF
@@ -1342,7 +1212,6 @@ close(23)
 
   REAL FUNCTION calc_JHF(NL,temp) ! homogenous freezing !! Khovosrotyanov & Sassen 1998 [KS98] eq. (7)
 
-    
     USE mo_submctl, ONLY : boltz, planck,surfi0,pi
     REAL, intent(in) :: NL, & !  number of water molecules per unit volume of the liquid
                             temp
@@ -1358,7 +1227,6 @@ close(23)
 
   REAL FUNCTION calc_act_energy(temp,nucltype) ! activation energy of solution ice interface  !!check
 
-    
     REAL, INTENT(in) :: temp
     CHARACTER(len=*), INTENT(in) :: nucltype
     REAL :: Tc
@@ -1383,16 +1251,15 @@ close(23)
 
   ! ------------------------------------------------------------
 
-  REAL FUNCTION calc_crit_energy(rn,prv,prs,temp) ! critical energy KC[00] (eq. 2.10) !!huomhuom #arvo
-    
-    USE mo_submctl, ONLY : surfi0
+  REAL FUNCTION calc_crit_energy(rn,prv,prs,temp) ! critical energy KC[00] (eq. 2.10)
+    USE mo_submctl, ONLY : surfi0, pi
     REAL, INTENT(in) :: rn, prv,prs, temp
     REAL :: mis, r_g, x, sigma_is,sigma_ns,sigma_ni
 
-    sigma_is = surfi0!! surface tension of ice-solution interface #arvo
-    sigma_ns = 1 ! #arvo
-    sigma_ni = 0.5 ! #arvo
-    alpha = 0 ! #arvo
+    sigma_is = surfi0!! surface tension of ice-solution interface
+    sigma_ns = 1
+    sigma_ni = 0.5
+    alpha = 0
 
     mis = (sigma_ns - sigma_ni )/sigma_is
     r_g = calc_r_g(sigma_is,prv,prs,temp)
@@ -1422,8 +1289,8 @@ close(23)
   ! ------------------------------------------------------------
 
   ! [KC00] eq. (2.6)
-  REAL FUNCTION calc_r_g(sigma_is,prv,prs,temp) !! calculate ice germ radius [KC00] !!huomhuom !! sigma_is #arvo
-    
+  REAL FUNCTION calc_r_g(sigma_is,prv,prs,temp) !! calculate ice germ radius [KC00]
+
     USE mo_submctl, ONLY : rhoic,rg,mwa
     REAL, intent(in) :: sigma_is, prv, prs, temp
     REAL :: Late, epsi,temp00,GG,C
@@ -1433,7 +1300,7 @@ close(23)
     C = 1.7e10 !! 1.7*10^10 Pa == 1.7*10^11 dyn cm^-2
     epsi = 0.025 ! 2.5%
     temp00 = calc_temp00(temp)
-    calc_r_g = 2.*sigma_is/( rhoic*Late*log((temp00/temp)*(prv/prs)**GG) -C*epsi**2) !! huomhuom täydennä
+    calc_r_g = 2.*sigma_is/( rhoic*Late*log((temp00/temp)*(prv/prs)**GG) -C*epsi**2)
 
   END FUNCTION calc_r_g
 
@@ -1450,7 +1317,7 @@ close(23)
 
 
     temp00 = calc_temp00(temp)
-    calc_r_cr = 2*surfi0/( rhoic*Late*log(temp00/temp)) !! huomhuom täydennä
+    calc_r_cr = 2*surfi0/( rhoic*Late*log(temp00/temp))
 
   END FUNCTION calc_r_cr
 
@@ -1468,7 +1335,7 @@ close(23)
 
   ! ------------------------------------------------------------
 
-  REAL function calc_temp00(temp) !!freezing point depression !! huomhuom korjaa parametrit ja täydennä #arvo
+  REAL function calc_temp00(temp) !!freezing point depression
     
     REAL, intent(in) :: temp
 
@@ -1482,19 +1349,12 @@ close(23)
                       pcloud,pice,pprecp,psnow,ppres, &
                       ptemp,prv,prs,ptstep )
 
-
-
-    
     USE mo_submctl, ONLY : t_section,   &
-                               ica,fca,     &
-                               icb,fcb,     &
                                ncld,        &
-                               iia,fia,     &
-                               iib,fib,     &
                                nice,        &
                                nsnw,        &
                                nprc,        &
-                               rhowa,       &
+                               rhowa, rhoic, rhosn,      &
                                pi6,         &
                                nlim, prlim
     USE mo_constants, ONLY : rd
@@ -1513,43 +1373,42 @@ close(23)
                                       psnow(kbdim,klev,nsnw),  &
                                       pprecp(kbdim,klev,nprc)
 
-
     INTEGER :: ii,jj,kk,ss
-    INTEGER :: hh
-    REAL :: zrh
 
-    DO ii = 1,kproma
+    DO ii = 1,kbdim
        DO jj = 1,klev
-          if (ptemp(ii,jj) < 273.15 ) cycle !!huomhuom add effect of freezing point depression
+          ! Ice and snow melt when temperature above 273.15 K
+          ! => should add the effect of freezing point depression
+          if (ptemp(ii,jj) <= 273.15 ) cycle
+
           DO kk = 1,nice
+              ! Ice => cloud water
+              IF (pice(ii,jj,kk)%numc<prlim) CYCLE
+              DO ss = 1,7
+                  pcloud(ii,jj,kk)%volc(ss) = pcloud(ii,jj,kk)%volc(ss) + pice(ii,jj,kk)%volc(ss)
+                  pice(ii,jj,kk)%volc(ss) = 0.
+              END DO
+              ss=8 ! Water
+              pcloud(ii,jj,kk)%volc(ss) = pcloud(ii,jj,kk)%volc(ss) + pice(ii,jj,kk)%volc(ss)*rhoic/rhowa
+              pice(ii,jj,kk)%volc(ss) = 0.
 
-             DO ss = 1,8
-                pcloud(ii,jj,kk)%volc(ss) = pice(ii,jj,kk)%volc(ss) + pcloud(ii,jj,kk)%volc(ss)
-                pice(ii,jj,kk)%volc(ss) = 0.
+              pcloud(ii,jj,kk)%numc = pcloud(ii,jj,kk)%numc + pice(ii,jj,kk)%numc
+              pice(ii,jj,kk)%numc = 0.
+          END DO
 
-             END DO
+          DO kk =1,nsnw
+              ! Snow => precipitation (bin 1)
+              IF (psnow(ii,jj,kk)%numc<prlim) CYCLE
+              DO ss = 1,7
+                  pprecp(ii,jj,kk)%volc(ss) = pprecp(ii,jj,kk)%volc(ss) + psnow(ii,jj,kk)%volc(ss)
+                  psnow(ii,jj,kk)%volc(ss) = 0.
+              END DO
+              ss=8 ! Water
+              pprecp(ii,jj,kk)%volc(ss) = pprecp(ii,jj,kk)%volc(ss) + psnow(ii,jj,kk)%volc(ss)*rhosn/rhowa
+              psnow(ii,jj,kk)%volc(ss) = 0.
 
-                DO ss = 1,8
-                        pcloud(ii,jj,kk)%volc(ss) = pice(ii,jj,kk)%volc(ss) + pcloud(ii,jj,kk)%volc(ss)
-                        pice(ii,jj,kk)%volc(ss) = 0.
-
-                END DO
-
-               pcloud(ii,jj,kk)%numc = pcloud(ii,jj,kk)%numc + pice(ii,jj,kk)%numc
-               pice(ii,jj,kk)%numc = 0.
-
-
-            END DO
-
-            DO kk =1,nsnw
-                DO ss = 1,8
-                        pprecp(ii,jj,kk)%volc(ss) = psnow(ii,jj,kk)%volc(ss) + pprecp(ii,jj,kk)%volc(ss)
-                        psnow(ii,jj,kk)%volc(ss) = 0.
-
-                END DO
-
-               pprecp(ii,jj,kk)%numc = pprecp(ii,jj,kk)%numc + psnow(ii,jj,kk)%numc
-               psnow(ii,jj,kk)%numc = 0.
+              pprecp(ii,jj,kk)%numc = pprecp(ii,jj,kk)%numc + psnow(ii,jj,kk)%numc
+              psnow(ii,jj,kk)%numc = 0.
             END DO
        END DO
     END DO
@@ -1566,14 +1425,10 @@ close(23)
   !
     
     USE mo_submctl, ONLY : t_section,   &
-                               iia,fia,     &
-                               iib,fib,     &
-                               isa,fsa,     &
                                nice,        &
                                nsnw,        &
-                               rhowa,       &
-                               pi6,         &
-                               nlim, debug
+                               rhosn, rhoic,       &
+                               prlim
     USE mo_constants, ONLY : rd
     IMPLICIT NONE
 
@@ -1582,63 +1437,43 @@ close(23)
     TYPE(t_section), INTENT(inout) :: psnow(kbdim,klev,nsnw)
 
     REAL :: Vrem, Nrem, Vtot, Ntot
-    REAL :: dvg,dg, frac
+    REAL :: dvg,dg
 
-    REAL, PARAMETER :: zd0 = 250.e-6  !! huomhuom tarvii varmaan tuunata
-    REAL, PARAMETER :: sigmag = 1.2   !! huomhuom tarvii varmaan tuunata
+    REAL, PARAMETER :: zd0 = 250.e-6  ! Adjustable
+    REAL, PARAMETER :: sigmag = 1.2   ! Adjustable
 
     INTEGER :: ii,jj,cc,ss
 
     ! Find the ice particle bins where the mean droplet diameter is above 250 um
     ! Do some fitting...
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
           DO cc = 1,nice
-
-             Vrem = 0.
-             Nrem = 0.
-             Ntot = 0.
-             Vtot = 0.
-             dvg = 0.
-             dg = 0.
 
              Ntot = pice(ii,jj,cc)%numc
              Vtot = SUM(pice(ii,jj,cc)%volc(:))
 
-             IF ( Ntot > 0. .AND. Vtot > 0. ) THEN
-!               write(*,*) 'autosnow Ntot, Vtot > 0 debugkebab'
+             IF ( Ntot > prlim .AND. Vtot > 0. ) THEN
                 ! Volume geometric mean diameter
                 dvg = pice(ii,jj,cc)%dwet*EXP( (3.*LOG(sigmag)**2)/2. )
                 dg = dvg*EXP( -3.*LOG(sigmag)**2 )
 
-                !testi = cumlognorm(2.19e-4,sigmag,zd0)
-                !WRITE(*,*) 'TESTAAN: ',testi
-
                 Vrem = Max(0., Vtot*( 1. - cumlognorm(dvg,sigmag,zd0) ) )
                 Nrem = Max(0., Ntot*( 1. - cumlognorm(dg,sigmag,zd0) )  )
 
-                IF ( Vrem < 0. ) WRITE(*,*) 'ERROR Vrem < 0', Vrem, Vtot
-                IF ( Vrem > Vtot ) WRITE(*,*) 'ERROR Vrem > Vtot', cumlognorm(dvg,sigmag,zd0),dvg,dg,Vtot
-                IF ( Nrem < 0. ) WRITE(*,*) 'ERROR Nrem < 0', Nrem
-                IF ( Nrem > Ntot ) WRITE(*,*) 'ERROR Nrem > Ntot', cumlognorm(dg,sigmag,zd0),dvg,dg,Ntot
+                IF ( Vrem > 0. .AND. Nrem > prlim) THEN
+                   ! Put the mass and number to the first snow bin and remover from cloud droplets
 
-                IF ( Vrem > 0. .AND. Nrem > 0.) THEN
-!                   write(*,*) 'autosnow Vrem, Nrem > 0 debugkebab'
-                   ! Put the mass and number to the first precipitation bin and remover from
-                   ! cloud droplets
-
-                   frac = MAX(0.,MIN(1.,min(Vrem/Vtot, Nrem/Ntot))) ! huomhuom
-
-
-                   DO ss = 1,8
-                      psnow(ii,jj,cc)%volc(ss) = max(0., psnow(ii,jj,cc)%volc(ss) + &
-                                                           pice(ii,jj,cc)%volc(ss)*frac)
-                      pice(ii,jj,cc)%volc(ss) = max(0., pice(ii,jj,cc)%volc(ss)*(1. - frac))
+                   DO ss = 1,7
+                      psnow(ii,jj,cc)%volc(ss) = max(0., psnow(ii,jj,cc)%volc(ss) + pice(ii,jj,cc)%volc(ss)*Nrem/Ntot)
+                      pice(ii,jj,cc)%volc(ss) = max(0., pice(ii,jj,cc)%volc(ss)*(1. - Nrem/Ntot))
                     END DO
+                    ! From ice to snow volume
+                    psnow(ii,jj,cc)%volc(8) = max(0., psnow(ii,jj,cc)%volc(8) + pice(ii,jj,cc)%volc(8)*Nrem/Ntot*rhoic/rhosn)
+                    pice(ii,jj,cc)%volc(8) = max(0., pice(ii,jj,cc)%volc(8)*(1. - Nrem/Ntot))
 
-                    psnow(ii,jj,cc)%numc = max( 0., psnow(ii,jj,cc)%numc + pice(ii,jj,cc)%numc*frac )
-                    pice(ii,jj,cc)%numc = max(0., pice(ii,jj,cc)%numc*(1. - frac) )
-
+                    psnow(ii,jj,cc)%numc = max( 0., psnow(ii,jj,cc)%numc + pice(ii,jj,cc)%numc*Nrem/Ntot )
+                    pice(ii,jj,cc)%numc = max(0., pice(ii,jj,cc)%numc*(1. - Nrem/Ntot) )
 
                 END IF ! Nrem Vrem
 
@@ -1647,7 +1482,6 @@ close(23)
           END DO ! cc
        END DO ! ii
     END DO ! jj
-    IF (debug)              write(*,*)  'nyt on autosnowattu ', ' debugkebab'
 
   END SUBROUTINE autosnow
 
@@ -1665,39 +1499,11 @@ close(23)
 
     REAL :: hlp1,hlp2
 
-    !cumlognorm = 0.
-
     hlp1 = ( LOG(dpart) - LOG(dg) )
     hlp2 = SQRT(2.)*LOG(sigmag)
     cumlognorm = 0.5 + 0.5*ERF( hlp1/hlp2 )
 
   END FUNCTION cumlognorm
-  !
-  ! ----------------------------------------------------------------
-  !
-  REAL FUNCTION errf(x)
-    
-    IMPLICIT NONE
-    ! (Approximative) Error function.
-    ! This is available as an intrinsic function as well but the implementation is somewhat compiler-specific
-    ! so an approximation is given here explicitly...
-
-    ! EI TOIMI OIKEIN ÄÄRIPÄISSÄ
-
-
-    REAL, INTENT(in) :: x
-    REAL :: hlp
-
-    hlp = 1. + 0.0705230784*x + 0.0422820123*(x**2) +  &
-          0.0092705272*(x**3) + 0.0001520143*(x**4) +       &
-          0.0002765672*(x**5) + 0.0000430638*(x**6)
-
-    errf = 1. - 1./(hlp**16)
-
-    WRITE(*,*) 'TESTAAN 2: ', x, errf
-
-  END FUNCTION errf
-
 
 
 

--- a/src/src_salsa/mo_salsa_driver.f90
+++ b/src/src_salsa/mo_salsa_driver.f90
@@ -76,7 +76,7 @@ IMPLICIT NONE
                        prunmode, prtcl, tstep, dbg2, time, level)
 
     USE mo_submctl, ONLY : nbins,ncld,nprc,pi6,          &
-                               nice,nsnw,		     &
+                               nice,nsnw,             &
                                rhoic,rhosn,                  &
                                rhowa, rhosu, rhobc, rhooc,   &
                                rhono, rhonh, rhoss, rhodu,   &
@@ -153,7 +153,7 @@ IMPLICIT NONE
     TYPE(t_section) :: actd(kbdim,klev,ncld) ! Activated droplets - for interfacing with SALSA
 
     ! Helper arrays for calculating the rates of change
-	TYPE(t_section) :: aero_old(1,1,nbins), cloud_old(1,1,ncld), precp_old(1,1,nprc), &
+    TYPE(t_section) :: aero_old(1,1,nbins), cloud_old(1,1,ncld), precp_old(1,1,nprc), &
        ice_old(1,1,nice), snow_old(1,1,nsnw)
 
     INTEGER :: jj,ii,kk,ss,str,end, nc,vc
@@ -474,7 +474,7 @@ IMPLICIT NONE
              If (prunmode == 1) CALL equilibration(kproma,kbdim,klev,   &
                                                     init_rh,in_t,aero,.TRUE.)
 
-	         ! Juha: Should be removed when possible
+             ! Juha: Should be removed when possible
              If (prunmode == 1) CALL equilibration_cloud(kproma,kbdim,klev,   &
                                                     in_rs,in_t,cloud,ice)
 
@@ -800,7 +800,7 @@ IMPLICIT NONE
 
                pa_gaerot(kk,ii,jj,5) = pa_gaerot(kk,ii,jj,5) + &
                   ( zgocsv(1,1)/pdn(kk,ii,jj) - pa_gaerop(kk,ii,jj,5) )/tstep
-		     ENDIF
+             ENDIF
 
 
              ! Tendency of water vapour mixing ratio is obtained from the change in RH during SALSA run.

--- a/src/src_salsa/mo_salsa_dynamics.f90
+++ b/src/src_salsa/mo_salsa_dynamics.f90
@@ -40,7 +40,7 @@ CONTAINS
   !  does not follow particle size in regime 2.
   !
   !Schematic for bin numbers in different regimes:
-  !        	 1             			2
+  !             1                            2
   !    +-------------------------------------------+
   !  a | 1 | 2 | 3 || 4 | 5 | 6 | 7 |  8 |  9 | 10||
   !  b |           ||11 |12 |13 |14 | 15 | 16 | 17||
@@ -1071,10 +1071,9 @@ CONTAINS
     IF (lscndgas) CALL condgas(kproma,  kbdim,  klev,   krow,      &
                           paero,   pcloud, pprecp,            &
                           pice,    psnow,                     &
-                          pcsa,                               &
-                          pcocnv,  pcocsv, pchno3, pcnh3,     &
-                          prv,prs, prsi,ptemp,  ppres,  ptstep,    &
-                          ppbl,    prtcl)
+                          pcsa, pcocnv, pcocsv, pchno3, pcnh3,     &
+                          zxsa, prv,prs, prsi,ptemp,  ppres, ptstep,    &
+                          prtcl)
 
     ! Condensation of water vapour
     IF (nlcndh2ocl .OR. nlcndh2oae .OR. nlcndh2oic) &
@@ -1099,8 +1098,8 @@ CONTAINS
                           pice,    psnow,                     &
                           pcsa,                               &
                           pcocnv,  pcocsv, pchno3, pcnh3,     &
-                          prv,prs, prsi,ptemp,  ppres,  ptstep,    &
-                          ppbl,    prtcl)
+                          zxsa, prv,prs, prsi,ptemp,  ppres,  ptstep,    &
+                          prtcl)
 
     USE mo_submctl,    ONLY :   &
          pi,                        &
@@ -1168,16 +1167,14 @@ CONTAINS
 
     TYPE(ComponentIndex), INTENT(in) :: prtcl  ! Keeps track which substances are used
 
-    INTEGER :: ppbl(kbdim)           ! Planetary boundary layer top level
-
     REAL, INTENT(INOUT) ::     &
-         !prh(kbdim,klev),          & ! Juha: Moved from above
          prv(kbdim,klev),          & ! Water vapor mixing ratio
          pcsa(kbdim,klev),         & ! sulphuric acid concentration [#/m3]
          pcocnv(kbdim,klev),       & ! non-volatile organic concentration [#/m3]
          pcocsv(kbdim,klev),       & ! semivolatile organic concentration [#/m3]
          pchno3(kbdim,klev),       & ! nitric acid concentration [#/m3]
-         pcnh3(kbdim,klev)           ! ammonia concentration [#/m3]
+         pcnh3(kbdim,klev),        & ! ammonia concentration [#/m3]
+         zxsa(kbdim,klev)            ! ratio of sulphuric acid and organic vapor in 3nm particles
 
     TYPE(t_section), INTENT(inout) :: &
          pcloud(kbdim,klev,ncld),     & ! Hydrometeor properties
@@ -1233,7 +1230,6 @@ CONTAINS
 
          zj3n3(kbdim,klev,2),        & ! Formation massrate of molecules in nucleation, [molec/m3s].  (kbdim,klev,1) for H2SO4 and (kbdim,klev,2) for Organic vapor
          zn_vs_c,                    & ! ratio of nucleation of all mass transfer in the smallest bin
-         zxsa(kbdim,klev),           & ! ratio of sulphuric acid and organic vapor in 3nm particles
          zxocnv(kbdim,klev)
 
 
@@ -1845,10 +1841,10 @@ CONTAINS
                    zwsatid(cc) = zkelvinid(cc)
                 END DO
              END IF
-			 IF (ANY(psnow(ii,jj,:)%numc > prlim) ) THEN
+             IF (ANY(psnow(ii,jj,:)%numc > prlim) ) THEN
                 DO cc = 1,nsnw
                    zcwintsd(cc) = zcwcsd(cc) + min(max(adt*zmtsd(cc)*(zcwint - zwsatsd(cc)*zcwsurfsd(cc)),&
-						-0.02*zcwcsd(cc)),0.05*zcwcsd(cc))
+                        -0.02*zcwcsd(cc)),0.05*zcwcsd(cc))
                    zwsatsd(cc) = zkelvinsd(cc)
                 END DO
              END IF

--- a/src/src_salsa/mo_salsa_dynamics.f90
+++ b/src/src_salsa/mo_salsa_dynamics.f90
@@ -103,12 +103,9 @@ CONTAINS
          in2a, fn2a,                 &
          in2b, fn2b,                 &
          ica,fca,icb,fcb,            &
-         ncld, nprc, ira,fra,        &
+         ncld, nprc,        &
          iia,fia,iib,fib,            &
-         nice, nsnw,isa,fsa,         &
-         debug,                      &
-         ncldbin,                    & ! Sizes of cloud and drizzle droplet regimes
-         nicebin,                    &
+         nice, nsnw,         &
          pi6,                        &
          rhosu,rhooc,rhono,rhonh,    &
          rhobc,rhodu,rhoss,rhowa,    &
@@ -120,12 +117,6 @@ CONTAINS
          lscgia, lscgic, lscgii, lscgip, &
          lscgsa, lscgsc, lscgsi, lscgsp, lscgss, &
          debug
-    !USE mo_aero_mem_salsa, ONLY :    &
-    !     d_cond_so4,                 & ! diagnostic variable for condensated mass of so4
-    !     d_nuc_so4                     !diagnostic variable for nucleated mass of so4
-    !USE mo_salsa_init, only: coagc
-    !USE mo_salsa_init, ONLY : coagc
-    
 
     IMPLICIT NONE
 
@@ -150,11 +141,9 @@ CONTAINS
     !-- Local variables ------------------------
     INTEGER ::                      &
          ii,jj,kk,ll,mm,nn,cc,      & ! loop indices
-         index_2a, index_2b,        & ! corresponding bin in regime 2a/2b
-         index_cd                     ! corresponding bin in cloud droplet regime
+         index_2a, index_2b        ! corresponding bin in regime 2a/2b
 
     REAL ::                     &
-         zntemp(kbdim,klev),        & ! variable for saving pnaero(fn2b) temporarily
          zcc(fn2b,fn2b),            & ! updated coagulation coefficients [m3/s]
          zcccc(ncld,ncld),          & ! - '' - for collision-coalescence [m3/s]
          zccca(fn2b,ncld),          & ! - '' - for cloud collection of aerosols [m3/s]
@@ -170,65 +159,64 @@ CONTAINS
          zccsi(nice,nsnw),          & ! - '' - for collection of ice by snow !!huomhuom
          zccsp(nprc,nsnw),          & ! - '' - for collection of precip by snow !!huomhuom
          zccss(nsnw,nsnw),          & ! - '' - for collitions between snow particles !!huomhuom
-
          zminusterm,                & ! coagulation loss in a bin [1/s]
          zplusterm(8)                 ! coagulation gain in a bin [fxm/s]
                                       ! (for each chemical compound)
-         !zcc(kbdim,klev,fn2b,fn2b), & ! updated coagulation coefficients [m3/s]
 
-    !REAL ::                     &
-    !     zrho(8)                     ! Table for densities of different species in hydrometeor distribution
     REAL :: &
          zmpart(fn2b),   & ! approximate mass of particles [kg]
          zmcloud(ncld),  &    ! approximate mass of cloud droplets [kg]
          zmprecp(nprc),  & ! Approximate mass for rain drops [kg]
          zmice(nice),     & ! approximate mass for ice particles [kg] !huomhuom
-         zmsnow(nsnw)     ! approximate mass for snow particles [kg] !!huomhuom
+         zmsnow(nsnw), &  ! approximate mass for snow particles [kg] !!huomhuom
+         zdpart(fn2b),   & ! diameter of particles [kg]
+         zdcloud(ncld),  &   ! diameter of cloud droplets [kg]
+         zdprecp(nprc),  & ! diameter for rain drops [kg]
+         zdice(nice),     & ! diameter for ice particles [kg] !huomhuom
+         zdsnow(nsnw)     ! diameter for snow particles [kg] !!huomhuom
 
     REAL :: &
-         temppi,pressi,pdmm,pdnn
-    REAL :: zsec(nprc), & ! Security coefficient
-                zsecs(nsnw)   ! Security coefficient for snow
+         temppi,pressi
 
-    !REAL :: &
-    !     zhvol(kbdim,klev,ncld),  &       ! Total volume concentration of hydrometeors
-    !     zavol(kbdim,klev,fn2b)           ! Total volume concentration of aerosols
-
-
-    REAL :: t1,t2
-
-    IF (debug) WRITE(*,*) 'coagulation init'
-
+    LOGICAL :: any_cloud, any_precp, any_ice, any_snow
 
     !-----------------------------------------------------------------------------
     !-- 1) Coagulation to coarse mode calculated in a simplified way: ------------
     !      CoagSink ~ Dp in continuum regime, thus we calculate
     !      'effective' number concentration of coarse particles
 
-    zntemp = paero(:,:,fn2b)%numc
 
     !-- 2) Updating coagulation coefficients -------------------------------------
 
-    IF (debug) WRITE(*,*) 'start kernels'
+    IF (debug) WRITE(*,*) 'start coagulation kernels'
 
      DO jj = 1,klev      ! vertical grid
-        DO ii = 1,kproma ! horizontal kproma in the slab
+        DO ii = 1,kbdim ! horizontal kproma in the slab
+           ! Which species are included
+           any_cloud = ANY(pcloud(ii,jj,:)%numc > nlim)
+           any_precp = ANY(pprecp(ii,jj,:)%numc > prlim)
+           any_ice = ANY(pice(ii,jj,:)%numc > prlim)
+           any_snow = ANY(psnow(ii,jj,:)%numc > prlim)
 
-           !-- particle mass; density of 1500 kg/m3 assumed [kg]
-           zmpart = pi6*(MIN(paero(ii,jj,1:fn2b)%dwet, 30.e-6)**3)*1500.
+           !-- Aerosol diameter [m] and mass [kg]; density of 1500 kg/m3 assumed
+           zdpart(1:fn2b) = MIN(paero(ii,jj,1:fn2b)%dwet, 30.e-6) ! Limit to 30 um
+           zmpart(1:fn2b) = pi6*(zdpart(1:fn2b)**3)*1500. ! Should calculate masses here (%dwet may be inaccurate)
 
-           !-- Cloud mass; Assume water density
-           zmcloud(1:ncld) = pi6*(pcloud(ii,jj,1:ncld)%dwet**3)*rhowa
+           !-- Cloud droplet diameter and mass; Assume water density
+           zdcloud(1:ncld) = pcloud(ii,jj,1:ncld)%dwet ! No size limit?
+           zmcloud(1:ncld) = pi6*(zdcloud(1:ncld)**3)*rhowa
 
-           !-- Precipitation mass
-           zmprecp(1:nprc) = pi6*(MIN(pprecp(ii,jj,1:nprc)%dwet, 2.e-3)**3)*rhowa
+           !-- Precipitation droplet diameter and mass
+           zdprecp(1:nprc) = MIN(pprecp(ii,jj,1:nprc)%dwet, 2.e-3) ! Limit to 2 mm
+           zmprecp(1:nprc) = pi6*(zdprecp(1:nprc)**3)*rhowa
 
-           !-- Ice mass;  huomhuom tarkista tämä, tärkeä
+           !-- Ice particle diameter and mass
+           zdice(1:nice) = MIN(pice(ii,jj,1:nice)%dwet, 2.e-3) ! Limit to 2 mm
+           zmice(1:nice) =   pi6*(zdice(1:nice)**3)*rhoic
 
-           zmice(1:nice) =   pi6*(MIN(pice(ii,jj,1:nice)%dwet, 2.e-3)**3)*rhoic
-
-           !-- Snow mass?? huomhuom tarkista tämä, tärkeä
-           zmsnow(1:nsnw) =  pi6*(MIN(psnow(ii,jj,1:nsnw)%dwet, 2.e-3)**3)*rhosn
+           !-- Snow diameter and mass
+           zdsnow(1:nsnw) = MIN(psnow(ii,jj,1:nsnw)%dwet, 2.e-3) ! Limit to 2 mm (too low!)
+           zmsnow(1:nsnw) =  pi6*(zdsnow(1:nsnw)**3)*rhosn
 
            temppi=ptemp(ii,jj)
            pressi=ppres(ii,jj)
@@ -248,190 +236,158 @@ CONTAINS
            zccsp = 0.
            zccss = 0.
 
-           zsec(:) = MERGE(1.,0.,pprecp(ii,jj,:)%numc > 1.e-10) ! Typical "physical" minimum number concentration for LES
-           zsecs(:)= MERGE(1.,0., psnow(ii,jj,:)%numc > 1.e-10)  ! Typical "physical" minimum number concentration for LES
-
-		   IF (debug .and. lscgaa) WRITE(*,*) 'before lscgaa ' !debugtulostus
            ! Aero-aero coagulation
            IF (lscgaa) THEN
-              pdmm = 0.
-              pdnn = 0.
               DO mm = 1,fn2b         ! smaller colliding particle
+                 IF (paero(ii,jj,mm)%numc<nlim) cycle
                  DO nn = mm,fn2b            ! larger colliding particle
-                    pdmm=MIN(paero(ii,jj,mm)%dwet, 30.e-6)
-                    pdnn=MIN(paero(ii,jj,nn)%dwet, 30.e-6)
-                    zcc(mm,nn) = coagc(pdmm,pdnn,zmpart(mm),zmpart(nn),temppi,pressi,1)
+                    IF (paero(ii,jj,nn)%numc<nlim) cycle
+                    zcc(mm,nn) = coagc(zdpart(mm),zdpart(nn),zmpart(mm),zmpart(nn),temppi,pressi,1)
                     zcc(nn,mm) = zcc(mm,nn)
                  END DO
               END DO
            END IF
-		   IF (debug .and. lscgcc) WRITE(*,*) 'before lscgcc ' !debugtulostus
-           ! Collision-coalescence between cloud droplets
-           IF (lscgcc .AND. ANY(pcloud(ii,jj,:)%numc > nlim)) THEN
-              pdmm = 0.
-              pdnn = 0.
+          ! Collision-coalescence between cloud droplets
+           IF (lscgcc .AND. any_cloud) THEN
               DO mm = 1,ncld
+                 IF (pcloud(ii,jj,mm)%numc<nlim) cycle
                  DO nn = mm,ncld
-                    pdmm = pcloud(ii,jj,mm)%dwet
-                    pdnn = pcloud(ii,jj,nn)%dwet
-                    zcccc(mm,nn) = coagc(pdmm,pdnn,zmcloud(mm),zmcloud(nn),temppi,pressi,2)
+                    IF (pcloud(ii,jj,nn)%numc<nlim) cycle
+                    zcccc(mm,nn) = coagc(zdcloud(mm),zdcloud(nn),zmcloud(mm),zmcloud(nn),temppi,pressi,2)
                     zcccc(nn,mm) = zcccc(mm,nn)
                  END DO
               END DO
            END IF
-		   IF (debug .and. lscgpp) WRITE(*,*) 'before lscgpp ' !debugtulostus
            ! Self-collection of rain drops
-           IF (lscgpp .AND. ANY(pprecp(ii,jj,:)%numc > prlim)) THEN
-              pdmm = 0.
-              pdnn = 0.
+           IF (lscgpp .AND. any_precp) THEN
               DO mm = 1,nprc
+                 IF (pprecp(ii,jj,mm)%numc<prlim) cycle
                  DO nn = mm,nprc
-                    pdmm = MIN(pprecp(ii,jj,mm)%dwet,2.e-3)
-                    pdnn = MIN(pprecp(ii,jj,nn)%dwet,2.e-3)
-                    zccpp(mm,nn) =  coagc(pdmm,pdnn,zmprecp(mm),zmprecp(nn),temppi,pressi,2)*zsec(mm)*zsec(nn)
+                    IF (pprecp(ii,jj,nn)%numc<prlim) cycle
+                    zccpp(mm,nn) =  coagc(zdprecp(mm),zdprecp(nn),zmprecp(mm),zmprecp(nn),temppi,pressi,2)
                     zccpp(nn,mm) = zccpp(mm,nn)
                  END DO
               END DO
            END IF
-		   IF (debug .and. lscgca) WRITE(*,*) 'before lscgca ' !debugtulostus
            ! Cloud collection of aerosols
-           IF (lscgca .AND. ANY(pcloud(ii,jj,:)%numc > nlim)) THEN
+           IF (lscgca .AND. any_cloud) THEN
               DO mm = 1,fn2b
+                 IF (paero(ii,jj,mm)%numc<nlim) cycle
                  DO nn = 1,ncld
-                    pdmm = MIN(paero(ii,jj,mm)%dwet, 30.e-6)
-                    pdnn = pcloud(ii,jj,nn)%dwet
-                    zccca(mm,nn) = coagc(pdmm,pdnn,zmpart(mm),zmcloud(nn),temppi,pressi,2)
+                    IF (pcloud(ii,jj,nn)%numc<nlim) cycle
+                    zccca(mm,nn) = coagc(zdpart(mm),zdcloud(nn),zmpart(mm),zmcloud(nn),temppi,pressi,2)
                  END DO
               END DO
            END IF
-		   IF (debug .and. lscgpa) WRITE(*,*) 'before lscgpa ' !debugtulostus
            ! Collection of aerosols by rain
-           IF (lscgpa .AND. ANY(pprecp(ii,jj,:)%numc > prlim)) THEN
+           IF (lscgpa .AND. any_precp) THEN
               DO mm = 1,fn2b
+                 IF (paero(ii,jj,mm)%numc<nlim) cycle
                  DO nn = 1,nprc
-                    pdmm = MIN(paero(ii,jj,mm)%dwet,30.e-6)
-                    pdnn = MIN(pprecp(ii,jj,nn)%dwet, 2.e-3)
-                    zccpa(mm,nn) = coagc(pdmm,pdnn,zmpart(mm),zmprecp(nn),temppi,pressi,2)*zsec(nn)
+                    IF (pprecp(ii,jj,nn)%numc<prlim) cycle
+                    zccpa(mm,nn) = coagc(zdpart(mm),zdprecp(nn),zmpart(mm),zmprecp(nn),temppi,pressi,2)
                  END DO
               END DO
            END IF
-		   IF (debug .and. lscgpc) WRITE(*,*) 'before lscgpc ' !debugtulostus 
            ! Collection of cloud droplets by rain
-           IF (lscgpc .AND. (ANY(pcloud(ii,jj,:)%numc > nlim) .AND. ANY(pprecp(ii,jj,:)%numc > prlim)) ) THEN
+           IF (lscgpc .AND. any_cloud .AND. any_precp) THEN
               DO mm = 1,ncld
+                 IF (pcloud(ii,jj,mm)%numc<nlim) cycle
                  DO nn = 1,nprc
-                    pdmm = pcloud(ii,jj,mm)%dwet
-                    pdnn = MIN(pprecp(ii,jj,nn)%dwet,2.e-3)
-                    zccpc(mm,nn) = coagc(pdmm,pdnn,zmcloud(mm),zmprecp(nn),temppi,pressi,2)!*zsec(nn)
+                    IF (pprecp(ii,jj,nn)%numc<prlim) cycle
+                    zccpc(mm,nn) = coagc(zdcloud(mm),zdprecp(nn),zmcloud(mm),zmprecp(nn),temppi,pressi,2)
                   END DO
               END DO
            END IF
-  	       IF (debug .and. lscgia) WRITE(*,*) 'before lscgia ' !debugtulostus
-           !  collection of aerosols by ice !!huomhuom
-           IF (lscgia .AND. ANY(pice(ii,jj,:)%numc > nlim) ) THEN
+           !  collection of aerosols by ice
+           IF (lscgia .AND. any_ice) THEN
               DO mm = 1,fn2b
+                 IF (paero(ii,jj,mm)%numc<nlim) cycle
                  DO nn = 1,nice
-                    pdmm = paero(ii,jj,mm)%dwet
-                    pdnn = MIN(pice(ii,jj,nn)%dwet,1.e-3)
-                    zccia(mm,nn) =  coagc(pdmm,pdnn,zmpart(mm),zmice(nn),temppi,pressi,2)!*zsec(mm)*zsec(nn) !! huomhuom kernel
-
+                    IF (pice(ii,jj,nn)%numc<prlim) cycle
+                    zccia(mm,nn) =  coagc(zdpart(mm),zdice(nn),zmpart(mm),zmice(nn),temppi,pressi,2)
                  END DO
               END DO
            END IF
-		   IF (debug .and. lscgic) WRITE(*,*) 'before lscgic ' !debugtulostus
-           !  collection of cloud particles droplets by ice
-           IF (lscgic .AND. (ANY(pice(ii,jj,:)%numc > nlim) .AND. ANY(pcloud(ii,jj,:)%numc > nlim)) ) THEN
+          !  collection of cloud particles droplets by ice
+           IF (lscgic .AND. any_ice .AND. any_cloud) THEN
               DO mm = 1,ncld
+                 IF (pcloud(ii,jj,mm)%numc<nlim) cycle
                  DO nn = 1,nice
-                    pdmm = pcloud(ii,jj,mm)%dwet
-                    pdnn = MIN(pice(ii,jj,nn)%dwet,1.e-3)
-                    zccic(mm,nn) = coagc(pdmm,pdnn,zmcloud(mm),zmice(nn),temppi,pressi,2)  !! huomhuom kernel  ?
+                    IF (pice(ii,jj,nn)%numc<prlim) cycle
+                    zccic(mm,nn) = coagc(zdcloud(mm),zdice(nn),zmcloud(mm),zmice(nn),temppi,pressi,2)
                  END DO
               END DO
            END IF
-
            !  collitions between ice particles
-           IF (lscgii .AND. ANY(pice(ii,jj,:)%numc > nlim) ) THEN  !huomhuom no testswitch
-              pdmm = 0.
-              pdnn = 0.
+           IF (lscgii .AND. any_ice) THEN
               DO mm = 1,nice
+                 IF (pice(ii,jj,mm)%numc<prlim) CYCLE
                  DO nn = mm,nice
-                    pdmm = MIN(pice(ii,jj,mm)%dwet,1.e-3)
-                    pdnn = MIN(pice(ii,jj,nn)%dwet,1.e-3)
-
-                    zccii(mm,nn) = coagc(pdmm,pdnn,zmice(mm),zmice(nn),temppi,pressi,2)
+                    IF (pice(ii,jj,nn)%numc<prlim) CYCLE
+                    zccii(mm,nn) = coagc(zdice(mm),zdice(nn),zmice(mm),zmice(nn),temppi,pressi,2)
                     zccii(nn,mm) = zcccc(mm,nn)
                  END DO
               END DO
            END IF
-
-		   IF (debug .and. lscgip) WRITE(*,*) 'before lscgip ' !debugtulostus
            !  collection of precip by ice-collision
-           IF (lscgip .AND. (ANY(pprecp(ii,jj,:)%numc > prlim) .AND. ANY(pice(ii,jj,:)%numc > nlim)) ) THEN
+           IF (lscgip .AND. any_precp .AND. any_ice) THEN
               DO mm = 1,nprc
+                 IF (pprecp(ii,jj,mm)%numc<prlim) CYCLE
                  DO nn = 1,nice
-                    pdmm = MIN(pprecp(ii,jj,mm)%dwet,2.e-3)
-                    pdnn = MIN(pice(ii,jj,nn)%dwet,1.e-3)
-                    zccip(mm,nn) = coagc(pdmm,pdnn,zmprecp(mm),zmice(nn),temppi,pressi,2)!*zsec(nn) !! huomhuom kernel  ?
+                    IF (pice(ii,jj,nn)%numc<prlim) CYCLE
+                    zccip(mm,nn) = coagc(zdprecp(mm),zdice(nn),zmprecp(mm),zmice(nn),temppi,pressi,2)
                   END DO
               END DO
            END IF
-
            ! Self-collection of snow particles
-           IF (lscgss .AND. ANY(psnow(ii,jj,:)%numc > nlim ) ) THEN
-              pdmm = 0.
-              pdnn = 0.
+           IF (lscgss .AND. any_snow) THEN
               DO mm = 1,nsnw
+                 IF (psnow(ii,jj,mm)%numc<prlim) CYCLE
                  DO nn = mm,nsnw
-                    pdmm = MIN(psnow(ii,jj,mm)%dwet,1.e-3)
-                    pdnn = MIN(psnow(ii,jj,nn)%dwet,1.e-3)
-                    zccss(mm,nn) =  coagc(pdmm,pdnn,zmsnow(mm),zmsnow(nn),temppi,pressi,2)*zsecs(mm)*zsecs(nn) !! huomhuom kernel?  ?
+                    IF (psnow(ii,jj,nn)%numc<prlim) CYCLE
+                    zccss(mm,nn) =  coagc(zdsnow(mm),zdsnow(nn),zmsnow(mm),zmsnow(nn),temppi,pressi,2)
                     zccss(nn,mm) = zccss(mm,nn)
                  END DO
               END DO
            END IF
-
-           IF (debug .and. lscgsa) WRITE(*,*) 'before lscgsa ' !debugtulostus
            ! Collection of aerosols by snow
-           IF (lscgsa .AND. ANY(psnow(ii,jj,:)%numc > nlim ) ) THEN
+           IF (lscgsa .AND. any_snow) THEN
               DO mm = 1,fn2b
+                 IF (paero(ii,jj,mm)%numc<nlim) CYCLE
                  DO nn = 1,nsnw
-                    pdmm = paero(ii,jj,mm)%dwet
-                    pdnn = MIN(psnow(ii,jj,nn)%dwet, 1.e-3)
-                    zccsa(mm,nn) = coagc(pdmm,pdnn,zmpart(mm),zmsnow(nn),temppi,pressi,2)*zsecs(nn) !! huomhuom kernel?  ?
+                    IF (psnow(ii,jj,nn)%numc<prlim) CYCLE
+                    zccsa(mm,nn) = coagc(zdpart(mm),zdsnow(nn),zmpart(mm),zmsnow(nn),temppi,pressi,2)
                  END DO
               END DO
            END IF
-		   IF (debug .and. lscgsp) WRITE(*,*) 'before lscgsp ' !debugtulostus
            ! collection of precip by snow
-           IF (lscgsp .AND. (ANY(pprecp(ii,jj,:)%numc > prlim) .AND. ANY(psnow(ii,jj,:)%numc > nlim))) THEN
+           IF (lscgsp .AND. any_precp .AND. any_snow) THEN
               DO mm = 1,nprc
+                 IF (pprecp(ii,jj,mm)%numc<prlim) CYCLE
                  DO nn = 1,nsnw
-                    pdmm = MIN(pprecp(ii,jj,mm)%dwet,2.e-3)
-                    pdnn = MIN(psnow(ii,jj,nn)%dwet,1.e-3)
-                    zccsp(mm,nn) = coagc(pdmm,pdnn,zmprecp(mm),zmsnow(nn),temppi,pressi,2)*zsec(mm)*zsecs(nn) !! huomhuom kernel  ?
+                    IF (psnow(ii,jj,nn)%numc<prlim) CYCLE
+                    zccsp(mm,nn) = coagc(zdprecp(mm),zdsnow(nn),zmprecp(mm),zmsnow(nn),temppi,pressi,2)
                   END DO
               END DO
            END IF
-		   IF (debug .and. lscgsc) WRITE(*,*) 'before lscgsc ' !debugtulostus
            ! collection of cloud droples by snow
-           IF (lscgsc .AND. (ANY(pcloud(ii,jj,:)%numc > nlim) .AND. ANY(psnow(ii,jj,:)%numc > nlim))) THEN
+           IF (lscgsc .AND. any_cloud .AND. any_snow) THEN
               DO mm = 1,ncld
+                 IF (pcloud(ii,jj,mm)%numc<nlim) CYCLE
                  DO nn = 1,nsnw
-                    pdmm = pcloud(ii,jj,mm)%dwet
-                    pdnn = MIN(psnow(ii,jj,nn)%dwet,1.e-3)
-                    zccsc(mm,nn) = coagc(pdmm,pdnn,zmcloud(mm),zmsnow(nn),temppi,pressi,2)*zsecs(nn) !! huomhuom kernel  ?
+                    IF (psnow(ii,jj,nn)%numc<prlim) CYCLE
+                    zccsc(mm,nn) = coagc(zdcloud(mm),zdsnow(nn),zmcloud(mm),zmsnow(nn),temppi,pressi,2)
                   END DO
               END DO
            END IF
-		   IF (debug .and. lscgsi) WRITE(*,*) 'before lscgsi ' !debugtulostus
            ! collection of ice by snow
-           IF (lscgsi .AND. (ANY(pice(ii,jj,:)%numc > prlim) .AND. ANY(psnow(ii,jj,:)%numc > nlim))) THEN
+           IF (lscgsi .AND. any_ice .AND. any_snow) THEN
               DO mm = 1,nice
+                 IF (pice(ii,jj,mm)%numc<prlim) CYCLE
                  DO nn = 1,nsnw
-                    pdmm = MIN(pice(ii,jj,mm)%dwet,1.e-3)
-                    pdnn = MIN(psnow(ii,jj,nn)%dwet,2.e-3)
-                    zccsi(mm,nn) = coagc(pdmm,pdnn,zmice(mm),zmsnow(nn),temppi,pressi,2)*zsecs(nn) !! huomhuom kernel  ?
+                    IF (psnow(ii,jj,nn)%numc<prlim) CYCLE
+                    zccsi(mm,nn) = coagc(zdice(mm),zdsnow(nn),zmice(mm),zmsnow(nn),temppi,pressi,2)
                   END DO
               END DO
            END IF
@@ -442,6 +398,7 @@ CONTAINS
            ! Aerosols in regime 1a
            ! --------------------------------
            DO kk = in1a,fn1a
+              IF (paero(ii,jj,kk)%numc<nlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -471,20 +428,12 @@ CONTAINS
               END DO
 
               DO ll = in1a,kk-1
-                 zplusterm(1:2) = zplusterm(1:2) + zcc(ll,kk)*paero(ii,jj,ll)%volc(1:2)
-                 zplusterm(6:7) = zplusterm(6:7) + zcc(ll,kk)*paero(ii,jj,ll)%volc(6:7)
-                 zplusterm(8) = zplusterm(8) + zcc(ll,kk)*paero(ii,jj,ll)%volc(8)
+                 zplusterm(1:8) = zplusterm(1:8) + zcc(ll,kk)*paero(ii,jj,ll)%volc(1:8)
               END DO
 
               !-- Volume and number concentrations after coagulation update [fxm]
-              paero(ii,jj,kk)%volc(1:2) = ( paero(ii,jj,kk)%volc(1:2)+ptstep*zplusterm(1:2) * &
+              paero(ii,jj,kk)%volc(1:8) = ( paero(ii,jj,kk)%volc(1:8)+ptstep*zplusterm(1:8) * &
                    paero(ii,jj,kk)%numc ) / (1. + ptstep*zminusterm)
-
-              paero(ii,jj,kk)%volc(6:7) = ( paero(ii,jj,kk)%volc(6:7)+ptstep*zplusterm(6:7) * &
-                   paero(ii,jj,kk)%numc ) / (1. + ptstep*zminusterm)
-
-              paero(ii,jj,kk)%volc(8) = ( paero(ii,jj,kk)%volc(8)+ptstep*zplusterm(8) * &
-                   paero(ii,jj,kk)%numc ) / ( 1. + ptstep*zminusterm)
 
               paero(ii,jj,kk)%numc = paero(ii,jj,kk)%numc/(1. + ptstep*zminusterm  + &
                    0.5*ptstep*zcc(kk,kk)*paero(ii,jj,kk)%numc)
@@ -494,6 +443,7 @@ CONTAINS
            ! Aerosols in regime 2a
            ! ---------------------------------
            DO kk = in2a,fn2a
+              IF (paero(ii,jj,kk)%numc<nlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -533,21 +483,12 @@ CONTAINS
 
               ! Particle volume gained from smaller particles in regimes 1, 2a and 2b
               DO ll = in1a, kk-1
-                 zplusterm(1:2) = zplusterm(1:2) + zcc(ll,kk)*paero(ii,jj,ll)%volc(1:2)
-                 zplusterm(6:7) = zplusterm(6:7) + zcc(ll,kk)*paero(ii,jj,ll)%volc(6:7) ! NO + NH
-                 zplusterm(8) = zplusterm(8) + zcc(ll,kk)*paero(ii,jj,ll)%volc(8) ! for h2o
-              END DO
-
-              ! Particle volume gained from smaller particles in 2a
-              ! (Note, for components not included in the previous loop!)
-              DO ll = in2a, kk-1
-                 ! Don't do water twice!
-                 zplusterm(3:5) = zplusterm(3:5) + zcc(ll,kk)*paero(ii,jj,ll)%volc(3:5)
+                 zplusterm(1:8) = zplusterm(1:8) + zcc(ll,kk)*paero(ii,jj,ll)%volc(1:8)
               END DO
 
               ! Particle volume gained from smaller (and equal) particles in 2b
               DO ll = in2b, index_2b
-                 zplusterm(1:8) = zplusterm(1:8) + zcc(ll,kk)*paero(ii,jj,ll)%volc(1:8) ! 2b
+                 zplusterm(1:8) = zplusterm(1:8) + zcc(ll,kk)*paero(ii,jj,ll)%volc(1:8)
               END DO
 
               !-- Volume and number concentrations after coagulation update [fxm]
@@ -562,6 +503,7 @@ CONTAINS
            ! Aerosols in regime 2b
            ! ---------------------------------
            DO kk = in2b,fn2b
+              IF (paero(ii,jj,kk)%numc<nlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -601,13 +543,7 @@ CONTAINS
 
               ! Particle volume gained from smaller particles in 1/2a
               DO ll = in1a, index_2a-1
-                 zplusterm(1:2) = zplusterm(1:2) + zcc(ll,kk)*paero(ii,jj,ll)%volc(1:2)
-                 zplusterm(6:7) = zplusterm(6:7) + zcc(ll,kk)*paero(ii,jj,ll)%volc(6:7)
-                 zplusterm(8) = zplusterm(8) + zcc(ll,kk)*paero(ii,jj,ll)%volc(8)
-              END DO
-              DO ll = in2a, index_2a-1
-                 ! Don't do water twice!
-                 zplusterm(3:5) = zplusterm(3:5) + zcc(ll,kk)*paero(ii,jj,ll)%volc(3:5)
+                 zplusterm(1:8) = zplusterm(1:8) + zcc(ll,kk)*paero(ii,jj,ll)%volc(1:8)
               END DO
 
               ! Particle volume gained from smaller particles in 2b
@@ -626,8 +562,8 @@ CONTAINS
 
            ! Cloud droplets, regime a
            ! ------------------------------------------------
-           IF ( ANY(pcloud(ii,jj,:)%numc > nlim) ) THEN
-              DO cc = ica%cur,fca%cur
+           DO cc = ica%cur,fca%cur
+              IF (pcloud(ii,jj,cc)%numc<nlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -661,7 +597,6 @@ CONTAINS
                  zminusterm = zminusterm + zccsc(cc,ll)*psnow(ii,jj,ll)%numc
               END DO
 
-
               ! Volume gained from cloud collection of aerosols
               DO ll = in1a,fn2b
                  zplusterm(1:8) = zplusterm(1:8) + zccca(ll,cc)*paero(ii,jj,ll)%volc(1:8)
@@ -682,7 +617,7 @@ CONTAINS
                    ptstep*zplusterm(1:8)*pcloud(ii,jj,cc)%numc ) /         &
                    (1. + ptstep*zminusterm) )
 
-              ! Update the hydrometeor number concentration (Removal by coagulation with lrger bins and self)
+              ! Update the hydrometeor number concentration (Removal by coagulation with larger bins and self)
               pcloud(ii,jj,cc)%numc = max(0., pcloud(ii,jj,cc)%numc/( 1. + ptstep*zminusterm +  &
                    0.5*ptstep*zcccc(cc,cc)*pcloud(ii,jj,cc)%numc ) )
 
@@ -691,6 +626,7 @@ CONTAINS
            ! Cloud droplets, regime b
            ! -----------------------------------------
            DO cc = icb%cur,fcb%cur
+              IF (pcloud(ii,jj,cc)%numc<nlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -713,18 +649,15 @@ CONTAINS
                  zminusterm = zminusterm + zccpc(cc,ll)*pprecp(ii,jj,ll)%numc
               END DO
 
-              ! ice'n'snow
               ! Droplets lost by collection by ice
               DO ll = 1,nice
                  zminusterm = zminusterm + zccic(cc,ll)*pice(ii,jj,ll)%numc
               END DO
 
-              ! ice'n'snow
               ! Droplets lost by collection by snow particles
               DO ll = 1,nsnw
                  zminusterm = zminusterm + zccsc(cc,ll)*psnow(ii,jj,ll)%numc
               END DO
-
 
               ! Volume gained from cloud collection of aerosols
               DO ll = in1a,fn2b
@@ -750,13 +683,12 @@ CONTAINS
               pcloud(ii,jj,cc)%numc = max(0.,pcloud(ii,jj,cc)%numc/( 1. + ptstep*zminusterm +  &
                    0.5*ptstep*zcccc(cc,cc)*pcloud(ii,jj,cc)%numc ) )
 
-              END DO
-           END IF ! nlim
+           END DO
 
            ! Rain drops
            ! -----------------------------------
-           IF ( ANY(pprecp(ii,jj,:)%numc > prlim) ) THEN
-              DO cc = 1,nprc
+           DO cc = 1,nprc
+              IF (pprecp(ii,jj,cc)%numc<prlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -771,7 +703,7 @@ CONTAINS
                  zminusterm = zminusterm + zccsp(cc,ll)*psnow(ii,jj,ll)%numc
               END DO
 
-              ! Drops lost by collisions with ice  !! ice'n'precp huomhuom
+              ! Drops lost by collisions with ice
               DO ll = 1,nice
                  zminusterm = zminusterm + zccip(cc,ll)*pice(ii,jj,ll)%numc
               END DO
@@ -787,29 +719,25 @@ CONTAINS
               END DO
 
               ! Volume gained from smaller drops
-              IF (cc > 1) THEN
               DO ll = 1,cc-1
                  zplusterm(1:8) = zplusterm(1:8) + zccpp(ll,cc)*pprecp(ii,jj,ll)%volc(1:8)
               END DO
-              END IF
 
               ! Update the hydrometeor volume concentrations
               pprecp(ii,jj,cc)%volc(1:8) = max(0., ( pprecp(ii,jj,cc)%volc(1:8) +  &
                    ptstep*zplusterm(1:8)*pprecp(ii,jj,cc)%numc ) /         &
                    (1. + ptstep*zminusterm) )
 
-
               ! Update the hydrometeor number concentration (Removal by coagulation with lrger bins and self)
               pprecp(ii,jj,cc)%numc = max(0.,pprecp(ii,jj,cc)%numc/( 1. + ptstep*zminusterm +  &
                    0.5*ptstep*zccpp(cc,cc)*pprecp(ii,jj,cc)%numc ) )
 
            END DO
-        END IF  !prlim
 
-          ! Ice particles, regime a
+           ! Ice particles, regime a
            ! ------------------------------------------------
-		IF ( ANY(pice(ii,jj,:)%numc > nlim) ) THEN
            DO cc = iia%cur,fia%cur
+              IF (pice(ii,jj,cc)%numc<prlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -828,7 +756,6 @@ CONTAINS
                  zminusterm = zminusterm + zccii(cc,ll)*pice(ii,jj,ll)%numc
               END DO
 
-
               ! Particles lost by collection by snow drops
               DO ll = 1,nsnw
                  zminusterm = zminusterm + zccsi(cc,ll)*psnow(ii,jj,ll)%numc
@@ -841,16 +768,13 @@ CONTAINS
 
               ! Volume gained from ice collection of aerosols
               DO ll = in1a,fn2b
-                 zplusterm(1:8) = zplusterm(1:8) + zccia(ll,cc)*paero(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccia(ll,cc)*paero(ii,jj,ll)%volc(1:8)*rhowa/rhoic
               END DO
-
 
               ! Volume gained from cloud collection
               DO ll = 1,ncld
-                 zplusterm(1:8) = zplusterm(1:8) + zccic(ll,cc)*pcloud(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccic(ll,cc)*pcloud(ii,jj,ll)%volc(1:8)*rhowa/rhoic
               END DO
-
-
 
               ! Volume gained from smaller droplets in a
               DO ll = iia%cur,cc-1
@@ -862,8 +786,6 @@ CONTAINS
                  zplusterm(1:8) = zplusterm(1:8) + zccii(ll,cc)*pice(ii,jj,ll)%volc(1:8)
               END DO
 
-              !! huomhuom ice + precp collision?
-
               ! Update the hydrometeor volume concentrations
               pice(ii,jj,cc)%volc(1:8) = max(0., ( pice(ii,jj,cc)%volc(1:8) +  &
                    ptstep*zplusterm(1:8)*pice(ii,jj,cc)%numc ) /         &
@@ -873,12 +795,12 @@ CONTAINS
               pice(ii,jj,cc)%numc = max(0.,pice(ii,jj,cc)%numc/( 1. + ptstep*zminusterm +  &
                    0.5*ptstep*zccii(cc,cc)*pice(ii,jj,cc)%numc ) )
 
-
            END DO
 
            ! Ice particles, regime b
            ! -----------------------------------------
            DO cc = iib%cur,fib%cur
+              IF (pice(ii,jj,cc)%numc<prlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -906,17 +828,14 @@ CONTAINS
                  zminusterm = zminusterm + zccip(ll,cc)*pice(ii,jj,ll)%numc
               END DO
 
-
-
-
               ! Volume gained from ice collection of aerosols
               DO ll = in1a,fn2b
-                 zplusterm(1:8) = zplusterm(1:8) + zccia(ll,cc)*paero(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccia(ll,cc)*paero(ii,jj,ll)%volc(1:8)*rhowa/rhoic
               END DO
 
               ! Volume gained from cloud collection
               DO ll = 1,ncld
-                 zplusterm(1:8) = zplusterm(1:8) + zccic(ll,cc)*pcloud(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccic(ll,cc)*pcloud(ii,jj,ll)%volc(1:8)*rhowa/rhoic
               END DO
 
               ! Volume gained from smaller droplets in b
@@ -938,14 +857,12 @@ CONTAINS
               pice(ii,jj,cc)%numc = max(0.,pice(ii,jj,cc)%numc/( 1. + ptstep*zminusterm +  &
                    0.5*ptstep*zccii(cc,cc)*pice(ii,jj,cc)%numc ) )
 
-
            END DO
-		END IF !nlim
 
-           ! Snow drops
+           ! Snow
            ! -----------------------------------
-		IF ( ANY(psnow(ii,jj,:)%numc > nlim) ) THEN
            DO cc = 1,nsnw
+              IF (psnow(ii,jj,cc)%numc<prlim) CYCLE
 
               zminusterm = 0.
               zplusterm(:) = 0.
@@ -957,36 +874,35 @@ CONTAINS
 
               ! Volume gained by collection of aerosols
               DO ll = in1a,fn2b
-                 zplusterm(1:8) = zplusterm(1:8) + zccsa(ll,cc)*paero(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccsa(ll,cc)*paero(ii,jj,ll)%volc(1:8)*rhowa/rhosn
               END DO
 
               ! Volume gained by collection of cloud droplets
               DO ll = 1,ncld
-                 zplusterm(1:8) = zplusterm(1:8) + zccsc(ll,cc)*pcloud(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccsc(ll,cc)*pcloud(ii,jj,ll)%volc(1:8)*rhowa/rhosn
               END DO
 
               ! Volume gained by collection of ice particles
               DO ll = 1,nice
-                 zplusterm(1:8) = zplusterm(1:8) + zccsi(ll,cc)*pice(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccsi(ll,cc)*pice(ii,jj,ll)%volc(1:8)*rhoic/rhosn
               END DO
 
               ! Volume gained by collection of rain drops
               DO ll = 1,nprc
-                 zplusterm(1:8) = zplusterm(1:8) + zccsp(ll,cc)*pprecp(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccsp(ll,cc)*pprecp(ii,jj,ll)%volc(1:8)*rhowa/rhosn
               END DO
 
-               !Volume gained by collisions between ice and rain !! huomhuom ice'n'precp
+              ! Volume gained by collisions between ice and rain
               nn = min(nice,nprc)
               DO ll = 1,nn
-                 zplusterm(1:8) = zplusterm(1:8) + zccip(ll,cc)*pice(ii,jj,ll)%volc(1:8)*pprecp(ii,jj,ll)%volc(1:8)
+                 zplusterm(1:8) = zplusterm(1:8) + zccip(ll,cc)*pice(ii,jj,ll)%volc(1:8)*rhoic/rhosn* &
+                                                                  pprecp(ii,jj,ll)%volc(1:8)*rhowa/rhosn
               END DO
 
               ! Volume gained from smaller drops
-              IF (cc > 1) THEN
               DO ll = 1,cc-1
                  zplusterm(1:8) = zplusterm(1:8) + zccss(ll,cc)*psnow(ii,jj,ll)%volc(1:8)
               END DO
-              END IF
 
               ! Update the hydrometeor volume concentrations
               psnow(ii,jj,cc)%volc(1:8) = max(0.,( psnow(ii,jj,cc)%volc(1:8) +  &
@@ -996,23 +912,11 @@ CONTAINS
               ! Update the hydrometeor number concentration (Removal by coagulation with larger bins and self)
               psnow(ii,jj,cc)%numc = max(0.,psnow(ii,jj,cc)%numc/( 1. + ptstep*zminusterm +  &
                    0.5*ptstep*zccss(cc,cc)*psnow(ii,jj,cc)%numc ) )
+
            END DO
-		END IF !nlim
-
-
 
       END DO ! kbdim
      END DO ! klev
-     ! fxm: here we approximate that the sea salt regime 2b particles have
-     ! gained by coagulation can be treated as sulphate
-     paero(:,:,in2b:fn2b)%volc(1) = paero(:,:,in2b:fn2b)%volc(1) + paero(:,:,in2b:fn2b)%volc(5)
-     paero(:,:,in2b:fn2b)%volc(5) = 0.
-
-     DO cc = 1,8
-        paero(:,:,in2b:fn2b)%volc(cc) = MAX(paero(:,:,in2b:fn2b)%volc(cc), 0.)
-     END DO
-
-     if (debug) write(*,*)  'nyt on coaguloitu ', ' debugkebab'  !debugtulostus
 
   END SUBROUTINE coagulation
 
@@ -1099,26 +1003,115 @@ CONTAINS
     USE mo_salsa_nucleation
 
     USE mo_submctl,    ONLY :   &
+         t_section,                 & ! Data type for the cloud bin representation
+         fn2b,                      &
+         ncld,nprc,                  &
+         nice,nsnw,                 &
+         lscndgas,                  & 
+         nlcndh2oae, nlcndh2ocl, nlcndh2oic, & ! Condensation to aerosols, clouds and ice particles
+         nsnucl                     ! nucleation
+
+    USE class_componentIndex, ONLY : ComponentIndex,IsUsed
+
+    IMPLICIT NONE
+
+    !-- Input and output variables ----------
+    INTEGER, INTENT(IN) ::          &
+         kproma,                    & ! number of horiz. grid kproma
+         kbdim,                     & ! dimension for arrays
+         klev,                      & ! number of vertical klev
+         krow
+
+    REAL, INTENT(IN) ::         &
+         ptemp(kbdim,klev),         & ! ambient temperature [K]
+         ppres(kbdim,klev),         & ! ambient pressure [Pa]
+         ptstep,                    & ! timestep [s]
+         prs(kbdim,klev),           & ! Water vapor saturation mixing ratio
+         prsi(kbdim,klev)              ! Saturation mixing ratio    [kg/m3]
+
+    TYPE(ComponentIndex), INTENT(in) :: prtcl  ! Keeps track which substances are used
+
+    INTEGER :: ppbl(kbdim)           ! Planetary boundary layer top level
+
+    REAL, INTENT(INOUT) ::     &
+         prv(kbdim,klev),          & ! Water vapor mixing ratio
+         pcsa(kbdim,klev),         & ! sulphuric acid concentration [#/m3]
+         pcocnv(kbdim,klev),       & ! non-volatile organic concentration [#/m3]
+         pcocsv(kbdim,klev),       & ! semivolatile organic concentration [#/m3]
+         pchno3(kbdim,klev),       & ! nitric acid concentration [#/m3]
+         pcnh3(kbdim,klev)           ! ammonia concentration [#/m3]
+
+    TYPE(t_section), INTENT(inout) :: &
+         pcloud(kbdim,klev,ncld),     & ! Hydrometeor properties
+         paero(kbdim,klev,fn2b),      & ! Aerosol properties
+         pprecp(kbdim,klev,nprc),     & ! rain properties
+         pice(kbdim,klev,nice),       & ! ice properties
+         psnow(kbdim,klev,nsnw)        ! snowing properties
+
+    REAL :: zj3n3(kbdim,klev,2),        & ! Formation massrate of molecules in nucleation, [molec/m3s].  (kbdim,klev,1) for H2SO4 and (kbdim,klev,2) for Organic vapor
+         zxsa(kbdim,klev),           & ! ratio of sulphuric acid and organic vapor in 3nm particles
+         zxocnv(kbdim,klev), &
+         zrh(kbdim,klev)
+
+    zxocnv = 0.
+    zxsa = 0.
+    zj3n3 = 0.
+    zrh(1:kbdim,:) = prv(1:kbdim,:)/prs(1:kbdim,:)
+
+
+    !------------------------------------------------------------------------------
+
+    ! Nucleation
+    IF (nsnucl > 0) CALL nucleation(kproma, kbdim,  klev,   krow,   &
+                                    paero,  ptemp,  zrh,    ppres,  &
+                                    pcsa,   pcocnv, ptstep, zj3n3,  &
+                                    zxsa,   zxocnv, ppbl            )
+
+    ! Condensation of H2SO4 and organic vapors
+    IF (lscndgas) CALL condgas(kproma,  kbdim,  klev,   krow,      &
+                          paero,   pcloud, pprecp,            &
+                          pice,    psnow,                     &
+                          pcsa,                               &
+                          pcocnv,  pcocsv, pchno3, pcnh3,     &
+                          prv,prs, prsi,ptemp,  ppres,  ptstep,    &
+                          ppbl,    prtcl)
+
+    ! Condensation of water vapour
+    IF (nlcndh2ocl .OR. nlcndh2oae .OR. nlcndh2oic) &
+        CALL gpparth2o(kproma,kbdim,klev,krow,  &
+                   paero, pcloud, pprecp,   &
+                   pice, psnow,             & ! ice'n'snow
+                   ptemp,ppres,prs,prsi,prv,     &
+                   ptstep)
+
+    ! HNO3/NH3 - currently disabled
+    !CALL gpparthno3(kproma,kbdim,klev,krow,ppres,ptemp,paero,pcloud,   &
+    !                pprecp,pchno3,pcnh3,prv,prs,zbeta,ptstep           )
+
+  END SUBROUTINE condensation
+
+!
+! ----------------------------------------------------------------------------------------------------------
+!
+
+  SUBROUTINE condgas(kproma,  kbdim,  klev,   krow,      &
+                          paero,   pcloud, pprecp,            &
+                          pice,    psnow,                     &
+                          pcsa,                               &
+                          pcocnv,  pcocsv, pchno3, pcnh3,     &
+                          prv,prs, prsi,ptemp,  ppres,  ptstep,    &
+                          ppbl,    prtcl)
+
+    USE mo_submctl,    ONLY :   &
          pi,                        &
          pi6,                       & ! pi/6
          in1a, in2a,                & ! size bin indices
-         fn1a,                       &
-         fn2a, fn2b,                &
-         nbin,                      & ! number of size bins in each regime
-         nbins,                     & ! Total number of aerosol bins
-
+         fn2b,                &
          t_section,                 & ! Data type for the cloud bin representation
-         ica,fca,icb,fcb,           & ! bin indices for cloud/rain bins
-         ira,fra,                   &
-         iia,fia,iib,fib,           & ! bin indices for cloud/rain bins ! ice'n'snow
-         isa,fsa,                   &
          ncld,                      &
          nprc,                      &
          nice,                      & ! ice'n'snow
          nsnw,                      & ! ice'n'snow
-         debug,                     &
-         lscndgas,                  &
-         !lscndh2o,                  &
          avog,                      &
          nlim,                      &
          prlim,                     &
@@ -1151,15 +1144,10 @@ CONTAINS
          epsoc,                     & ! soluble fraction of organics (scaled to sulphate)
          massacc,                   & ! mass accomodation coefficients in each bin
          n3,                        & ! number of molecules in one 3 nm particle [1]
-         nsnucl,                    & ! nucleation
          surfw0,                    & ! surface tension of water
          surfi0                       ! surface tension of ice
 
-    
-
     USE class_componentIndex, ONLY : ComponentIndex,IsUsed
-
-    !USE mo_time_control,   ONLY: delta_time,time_step_len
 
     USE mo_constants,      ONLY: g, avo, alv, rv, als
    IMPLICIT NONE
@@ -1180,8 +1168,6 @@ CONTAINS
 
     TYPE(ComponentIndex), INTENT(in) :: prtcl  ! Keeps track which substances are used
 
-    !LOGICAL, INTENT(in) :: pactmask(kbdim,klev)
-
     INTEGER :: ppbl(kbdim)           ! Planetary boundary layer top level
 
     REAL, INTENT(INOUT) ::     &
@@ -1201,9 +1187,8 @@ CONTAINS
          psnow(kbdim,klev,nsnw)        ! snowing properties
 
 
-
     !-- Local variables ----------------------
-    INTEGER :: ii, jj, kk, ll, mm, cc    ! loop indices
+    INTEGER :: ii, jj    ! loop indices
 
     REAL ::                      &
          zvisc,                      & ! viscosity of air [kg/(m s)]
@@ -1213,71 +1198,35 @@ CONTAINS
          zcs_ocsv,                   & ! condensation sink for semivolatile organics [1/s]
          zcs_su,                     & ! condensation sink for sulfate [1/s]
          zcs_ocnv,                   & ! condensation sink for nonvolatile organics [1/s]
-         zcs_no,                     & ! condensation sink for NO3 [1/s]
-         zcs_nh,                     & ! condensation sink for NH3 [1/s]
-         zcs_h2o,                    & ! Condensation sink for H2O [1/s]
                                        ! vapour concentration after time step [#/m3]
          zcvap_new1,                 & ! sulphuric acid
          zcvap_new2,                 & ! nonvolatile organics
          zcvap_new3,                 & ! semivolatile organics
-         zcvap_newno,                & ! HNO3
-         zcvap_newnh,                & ! NH3
                                        ! change in vapour concentration [#/m3]
          zdvap1,                     & ! sulphuric acid
          zdvap2,                     & ! nonvolatile organics
          zdvap3,                     & ! semivolatile organics
-         zdvapno,                    & ! HNO3
-         zdvapnh,                    & ! NH3
 
          zdfpart(in1a+1),            & ! particle diffusion coefficient
-         zdfh2o,                     & ! diffusion coefficient for h2o vapour in air
 
          zknud(fn2b),                & ! particle Knudsen number
-         zknaw(fn2b),                & ! Kundsen number for aerosols and water vapour
-         zkncw(ncld),                & ! Knudsen number for cloud droplets and water vapour
          zknca(ncld),                & ! Knudsen number for cloud droplets and aerosol vapours
-         zknpw(nprc),                & ! Knudsen number for rain drops and water vapour
          zknpa(nprc),                & ! Knudsen number for rain drops and aerosol vapours
-         ! ice'n'snow
-         zkniw(nice),                & ! Knudsen number for ice particles and water vapour
          zknia(nice),                & ! Knudsen number for ice particles and aerosol vapours
-         zknsw(nsnw),                & ! Knudsen number for snow flakes and water vapour
          zknsa(nsnw),                & ! Knudsen number for snow flakes and aerosol vapours
 
-
-
          zbeta(fn2b),                & ! transitional correction factor for aerosols
-         zbetaaw(fn2b),              & ! - '' - for water condensing on aerosols
-         zbetacw(ncld),              & ! transitional correction for condensing water vapour on clouds (is this even needed?)
          zbetaca(ncld),              & ! - '' - for condensing aerosol vapours on clouds (is this needed?)
-         zbetapw(nprc),              & ! - '' - for condensing water on rain drops
          zbetapa(nprc),              & ! - '' - for condensing aerosol vapours on rain drops
-         ! ice'n'snow
-         zbetaiw(nice),              & ! transitional correction for condensing water vapour on ice particles
          zbetaia(nice),              & ! - '' - for condensing aerosol vapours on ice (is this needed?)
-         zbetasw(nsnw),              & ! - '' - for condensing water on snow flakes
          zbetasa(nsnw),              & ! - '' - for condensing aerosol vapours on snow flakes
 
          zcolrate(fn2b),             & ! collision rate of molecules to particles [1/s]
          zcolrate_ocnv(fn2b),        & ! collision rate of organic molecules to particles [1/s]
-         zcolrateaw(fn2b),           & ! Collision rate of water vapour on aerosols
-         zcolratecw(ncld),           & ! Collision rate of water vapour to cloud drops
          zcolrateca(ncld),           & ! Collision rate of aerosol vapour molecules to cloud drops
-         zcolratepw(nprc),           & ! Collision rate of water vapour to rain drops
          zcolratepa(nprc),           & ! Collision rate of gases to rain drops
-         ! ice'n'snow huomhuom onko nämä edes tarpeen
-         zcolrateiw(nice),           & ! Collision rate of water vapour to ice particles
          zcolrateia(nice),           & ! Collision rate of aerosol vapour molecules to ice particles
-         ! ice'n'snow huomhuom onko nämä edes tarpeen
-         zcolratesw(nsnw),           & ! Collision rate of water vapour to rain drops
          zcolratesa(nsnw),           & ! Collision rate of gases to rain drops
-
-         zmtae(fn2b),                & ! Mass transfer coefficients for aerosols
-         zmtcd(ncld),                & ! Mass transfer coefficients for cloud droplets
-         zmtpd(nprc),                & ! Mass transfer coefficients for rain drops
-         zmtid(nice),                & ! Mass transfer coefficients for ice particles
-         zmtsd(nsnw),                & ! Mass transfer coefficients for snow flakes
-         zmttot,                     & ! Total mass transfer coefficient
 
          zdvolsa(fn2b),              & ! change of sulphate volume in each bin [fxm]
          zdvoloc(fn2b),              & !    - " - organics
@@ -1285,59 +1234,16 @@ CONTAINS
          zj3n3(kbdim,klev,2),        & ! Formation massrate of molecules in nucleation, [molec/m3s].  (kbdim,klev,1) for H2SO4 and (kbdim,klev,2) for Organic vapor
          zn_vs_c,                    & ! ratio of nucleation of all mass transfer in the smallest bin
          zxsa(kbdim,klev),           & ! ratio of sulphuric acid and organic vapor in 3nm particles
-         zxocnv(kbdim,klev),         & !
-         zmaxdvol(fn2b),             & !
-         zcno_tot,                   & ! total available NO3
-         zcnh3_tot,                  & ! total available NH3
-
-         zthcond               ! thermal conductivity of air
-         !zmfph2o                   ! Mean free path for h2o vapour
-
-    REAL :: zns, znw    ! Number of moles of solute and water in particles
-
-    REAL :: zhlp1,zhlp2,zhlp3  ! Helper variables
-    REAL :: zhlp1a(ncld), zhlp2a(ncld), zhlp3a(ncld)
-    REAL :: zhlp1b(nbins), zhlp2b(nbins), zhlp3b(nbins)
-
-    real::ztmst,zqtmst,        &
-         ztstep2, ztstep_pre,zthno3,ztnh3,zph2o,zphno3,zpnh3,zaw
-
-    REAL :: zrh(kbdim,klev)
-
-   ! REAL :: zbetann(kbdim,klev,nbins) ! Correction factor for nitrate calculations
-
-                      ! FROM/TO ISOROPIA
-         REAL :: zwi_S(5)          ! Total species concentrations in moles/m**3 air
-         REAL :: zcntrl_s(2)       ! nug for different types of problems solved
-                                       ! different state of aerosols (deliquescent or
-                                       ! metastable)
-         REAL :: zwt_s(1)          ! ?
-         REAL :: zaerliq_S(12)     ! Aqueous-phase concentration array in moles/m**3air
-         REAL :: zaersld_S(9)      ! Solid-phase concentration array in moles/m**3 air
-         REAL :: zother_s(6)       ! Solution information array
-         REAL :: zgas_s(3)         ! Gas-phase concentration array in moles/m**3 air
-         CHARACTER*15 scasi_s          ! Returns the subcase which the input corresponds to
-    INTEGER, PARAMETER :: NCmax=3, NAmax=5, NNmax=1
-    REAL :: MOLAL(-NAmax:NCmax)    !-- Initializations
-    INTEGER :: tt
+         zxocnv(kbdim,klev)
 
 
-
-    zxocnv = 0.
-    zxsa = 0.
     zj3n3 = 0.
-    zrh(1:kproma,:) = prv(1:kproma,:)/prs(1:kproma,:)
+    zxocnv = 0.
 
-    !------------------------------------------------------------------------------
-
-    IF (nsnucl > 0) CALL nucleation(kproma, kbdim,  klev,   krow,   &
-                                    paero,  ptemp,  zrh,    ppres,  &
-                                    pcsa,   pcocnv, ptstep, zj3n3,  &
-                                    zxsa,   zxocnv, ppbl            )
     zdvolsa=0.
     zn_vs_c=0.
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
 
           zdvoloc = 0.
 
@@ -1345,8 +1251,6 @@ CONTAINS
           zvisc  = (7.44523e-3*ptemp(ii,jj)**1.5)/(5093.*(ptemp(ii,jj)+110.4))! viscosity of air [kg/(m s)]
           zdfvap = 5.1111e-10*ptemp(ii,jj)**1.75*pstand/ppres(ii,jj)                ! diffusion coefficient [m2/s]
           zmfp   = 3.*zdfvap*sqrt(pi*msu/(8.*rg*ptemp(ii,jj)))                      ! mean free path [m]
-
-          !zmfph2o = 3.*zdfh2o*sqrt(pi*mwa/(8.*rg*ptemp(ii,jj)))                                ! Mean free path fro h2o
 
           !-- 2) Transition regime correction factor for particles ---------
           !
@@ -1396,49 +1300,43 @@ CONTAINS
 
           !-- collision rate (gases on aerosols) [1/s]
           zcolrate = 0.
-          IF (lscndgas) &
-               zcolrate(in1a:in1a+1) = MERGE( 2.*pi*(paero(ii,jj,in1a:in1a+1)%dwet+d_sa)*    &
+          zcolrate(in1a:in1a+1) = MERGE( 2.*pi*(paero(ii,jj,in1a:in1a+1)%dwet+d_sa)*    &
                                               (zdfvap+zdfpart)*zbeta(in1a:in1a+1)*              &
                                               paero(ii,jj,in1a:in1a+1)%numc,                    &
                                               0.,                                            &
                                               paero(ii,jj,in1a:in1a+1)%numc > nlim              )
 
-          IF (lscndgas) &
-               zcolrate(in1a+2:fn2b) = MERGE( 2.*pi*paero(ii,jj,in1a+2:fn2b)%dwet*zdfvap*    &
+          zcolrate(in1a+2:fn2b) = MERGE( 2.*pi*paero(ii,jj,in1a+2:fn2b)%dwet*zdfvap*    &
                                               zbeta(in1a+2:fn2b)*paero(ii,jj,in1a+2:fn2b)%numc, &
                                               0.,                                            &
                                               paero(ii,jj,in1a+2:fn2b)%numc > nlim              )
 
           !-- gases on hydrometeors
           zcolrateca = 0.
-          IF (lscndgas) &
-               zcolrateca(1:ncld) = MERGE( 2.*pi*pcloud(ii,jj,1:ncld)%dwet*zdfvap*    &
+          zcolrateca(1:ncld) = MERGE( 2.*pi*pcloud(ii,jj,1:ncld)%dwet*zdfvap*    &
                                            zbetaca(1:ncld)*pcloud(ii,jj,1:ncld)%numc,    &
                                            0.,                                        &
                                            pcloud(ii,jj,1:ncld)%numc > nlim              )
 
           ! Gases on rain drops
           zcolratepa = 0.
-          IF (lscndgas) &
-               zcolratepa(1:nprc) = MERGE( 2.*pi*pprecp(ii,jj,1:nprc)%dwet*zdfvap*    &
+          zcolratepa(1:nprc) = MERGE( 2.*pi*pprecp(ii,jj,1:nprc)%dwet*zdfvap*    &
                                            zbetapa(1:nprc)*pprecp(ii,jj,1:nprc)%numc,    &
                                            0.,                                        &
-                                           pprecp(ii,jj,1:nprc)%numc > prlim             )          !-- gases on hydrometeors
+                                           pprecp(ii,jj,1:nprc)%numc > prlim             )
           !-- gases on ice particles
           zcolrateia = 0.
-          IF (lscndgas) &
-               zcolrateia(1:nice) = MERGE( 2.*pi*pice(ii,jj,1:nice)%dwet*zdfvap*    &
+          zcolrateia(1:nice) = MERGE( 2.*pi*pice(ii,jj,1:nice)%dwet*zdfvap*    &
                                            zbetaia(1:nice)*pice(ii,jj,1:nice)%numc,    &
                                            0.,                                        &
-                                           pice(ii,jj,1:ncld)%numc > nlim              )
+                                           pice(ii,jj,1:ncld)%numc > prlim              )
 
           ! Gases on snow flakes
           zcolratesa = 0.
-          IF (lscndgas) &
-               zcolratesa(1:nsnw) = MERGE( 2.*pi*psnow(ii,jj,1:nsnw)%dwet*zdfvap*    &
+          zcolratesa(1:nsnw) = MERGE( 2.*pi*psnow(ii,jj,1:nsnw)%dwet*zdfvap*    &
                                            zbetasa(1:nsnw)*psnow(ii,jj,1:nsnw)%numc,    &
                                            0.,                                        &
-                                           psnow(ii,jj,1:nsnw)%numc > nlim             )
+                                           psnow(ii,jj,1:nsnw)%numc > prlim             )
 
           !-- 4) Condensation sink [1/s] -------------------------------------
 
@@ -1600,20 +1498,7 @@ CONTAINS
 
     END DO ! klev
 
-    ! -- 5.3) Water vapour
-    CALL gpparth2o(kproma,kbdim,klev,krow,  &
-                   paero, pcloud, pprecp,   &
-                   pice, psnow,             & ! ice'n'snow
-                   ptemp,ppres,prs,prsi,prv,     &
-                   ptstep)
-
-    ! -- 5.4) HNO3/NH3
-    !CALL gpparthno3(kproma,kbdim,klev,krow,ppres,ptemp,paero,pcloud,   &
-    !                pprecp,pchno3,pcnh3,prv,prs,zbeta,ptstep           )
-
-  IF (debug)        write(*,*)  'nyt on condensoitu ', ' debugkebab'
-
-  END SUBROUTINE condensation
+  END SUBROUTINE condgas
 
 !
 ! ----------------------------------------------------------------------------------------------------------
@@ -1632,8 +1517,8 @@ CONTAINS
                                surfw0,surfi0, rg,           &
                                pi, prlim, nlim,      &
                                massacc,avog,pstand,  &
-                               in1a,fn1a,in2a,fn2a,  &
-                               in2b,fn2b,            &
+                               in1a,in2a,  &
+                               fn2b,            &
                                lscndh2oae, lscndh2ocl, lscndh2oic
     USE mo_constants, ONLY : alv, als  ! ice'n'snow
     USE mo_salsa_properties, ONLY : equilibration
@@ -1660,7 +1545,6 @@ CONTAINS
                 zmtid(nice), zmtsd(nsnw)
     REAL :: zwsatae(nbins), zwsatcd(ncld), zwsatpd(nprc), &  ! Water saturation ratios above
                 zwsatid(nice), zwsatsd(nsnw)                      ! ice'n'snow
-    REAL :: zmttot                                        ! Total condensation rate
     REAL :: zcwtot                                        ! Total water mole concentration
     REAL :: zcwc, zcwn, zcwint                            ! Current and new water vapour mole concentrations
     REAL :: zcwcae(nbins), zcwnae(nbins), zcwintae(nbins) ! Current and new water mole concentrations in aerosols
@@ -1668,7 +1552,6 @@ CONTAINS
     REAL :: zcwcpd(nprc), zcwnpd(nprc), zcwintpd(nprc)    !     -  ''  -     in rain drops
     REAL :: zcwcid(nice), zcwnid(nice), zcwintid(nice)    !     -  ''  -     in ice particles
     REAL :: zcwcsd(nsnw), zcwnsd(nsnw), zcwintsd(nsnw)    !     -  ''  -     in snow particles
-    REAL :: zdcwae(nbins), zdcwcd(ncld), zdcwpd(nprc),zdcwid(nice),zdcwsd(nsnw)
     REAL :: zdfh2o, zthcond,rhoair
     REAL :: zbeta,zknud,zmfph2o
     REAL :: zact, zhlp1,zhlp2,zhlp3
@@ -1713,7 +1596,7 @@ CONTAINS
     zwsatae = 0.; zwsatcd = 0.; zwsatpd = 0.; zwsatid = 0.; zwsatsd = 0.
 
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
 
           rhoair = mair*ppres(ii,jj)/(rg*ptemp(ii,jj))
 
@@ -1748,7 +1631,7 @@ CONTAINS
           zmtcd(:) = 0.
           zcwsurfcd(:) = 0.
           DO cc = 1,ncld
-             IF (pcloud(ii,jj,cc)%numc > prlim .AND. lscndh2ocl) THEN
+             IF (pcloud(ii,jj,cc)%numc > nlim .AND. lscndh2ocl) THEN
 
                 ! Activity + Kelvin effect
                 zact = acth2o(pcloud(ii,jj,cc))
@@ -1875,8 +1758,7 @@ CONTAINS
                 ! Water activity
                 zact = acth2o(paero(ii,jj,cc))
                 testi(cc) = zact
-                !                write(*,*) zact
-                ! Ssaturation mole concentration over flat surface
+                ! Saturation mole concentration over flat surface
                 ! Limit the supersaturation to max 1.01 for the mass transfer
                 ! EXPERIMENTAL
                 zcwsurfae(cc) = MAX(prs(ii,jj),prv(ii,jj)/1.01)*rhoair/mwa
@@ -1956,24 +1838,23 @@ CONTAINS
                    zwsatpd(cc) = acth2o(pprecp(ii,jj,cc),zcwintpd(cc))*zkelvinpd(cc)
                 END DO
              END IF
-             IF (ANY(pice(ii,jj,:)%numc > nlim) ) THEN
+             IF (ANY(pice(ii,jj,:)%numc > prlim) ) THEN
                 DO cc = 1,nice
                    zcwintid(cc) = zcwcid(cc) + min(max(adt*zmtid(cc)*(zcwint - zwsatid(cc)*zcwsurfid(cc)), &
                         -0.02*zcwcid(cc)),0.05*zcwcid(cc))
                    zwsatid(cc) = zkelvinid(cc)
                 END DO
              END IF
-             IF (ANY(psnow(ii,jj,:)%numc > nlim) ) THEN
+			 IF (ANY(psnow(ii,jj,:)%numc > prlim) ) THEN
                 DO cc = 1,nsnw
                    zcwintsd(cc) = zcwcsd(cc) + min(max(adt*zmtsd(cc)*(zcwint - zwsatsd(cc)*zcwsurfsd(cc)),&
-                        -0.02*zcwcsd(cc)),0.05*zcwcsd(cc))
+						-0.02*zcwcsd(cc)),0.05*zcwcsd(cc))
                    zwsatsd(cc) = zkelvinsd(cc)
                 END DO
              END IF
              zcwintae(nstr:nbins) = MAX(zcwintae(nstr:nbins),0.)
              zcwintcd(1:ncld) = MAX(zcwintcd(1:ncld),0.)
              zcwintpd(1:nprc) = MAX(zcwintpd(1:nprc),0.)
-             ! ice'n'snow
              zcwintid(1:nice) = MAX(zcwintid(1:nice),0.)
              zcwintsd(1:nsnw) = MAX(zcwintsd(1:nsnw),0.)
 
@@ -2014,7 +1895,7 @@ CONTAINS
   END SUBROUTINE gpparth2o
   !-------------------------------------------------------
   REAL FUNCTION acth2o(ppart,pcw)
-    
+
     USE mo_submctl, ONLY : t_section,  &
                                rhosu, msu,   &
                                rhooc, moc,   &
@@ -2026,7 +1907,6 @@ CONTAINS
 
     TYPE(t_section), INTENT(in) :: ppart
     REAL, INTENT(in), OPTIONAL :: pcw
-    !REAL, INTENT(out) :: pact
 
     REAL :: zns, znw
 
@@ -2055,7 +1935,6 @@ CONTAINS
     
     USE mo_submctl, ONLY : t_section,           &
                                nbins, ncld, nprc,   &
-                               in1a, fn2b,          &
                                surfw0, mvno, mvnh, boltz, &
                                rhono, mno,          &
                                rhonh, mnh,          &
@@ -2065,9 +1944,6 @@ CONTAINS
                                nlim, prlim
 
     IMPLICIT NONE
-
-    ! OTA MOLAALISUUDET PDFITESTA JA LASKE BETAT MYÖS PISAROILLE!!!!
-
 
     INTEGER, INTENT(in) :: kproma,kbdim,klev,krow
     REAL, INTENT(in) :: ptstep
@@ -2083,7 +1959,6 @@ CONTAINS
 
     REAL :: zkelno3ae(nbins), zkelno3cd(ncld), zkelno3pd(nprc)     ! Kelvin effects for HNO3
     REAL :: zkelnh3ae(nbins), zkelnh3cd(ncld), zkelnh3pd(nprc)     ! Kelvin effects for NH3
-    REAL :: zkelw(nbins), zkelwcd(ncld), zkelwpd(nprc)           ! Kelvin effects for H2O
 
     REAL :: zcno3cae(nbins), zcno3intae(nbins), zcno3nae(nbins),  & ! Current, intermediate and new HNO3 in aerosols
                 zcnh3cae(nbins), zcnh3intae(nbins), zcnh3nae(nbins),  & !  -  ''  - NH3
@@ -2096,9 +1971,6 @@ CONTAINS
 
     REAL :: zcno3c, zcno3int, zcno3n                             ! Current, intermediate and new HNO3 gas concentration
     REAL :: zcnh3c, zcnh3int, zcnh3n                             ! -  ''  - NH3
-
-    REAL :: zcno3eqae(nbins), zcno3eqcd(ncld), zcno3eqpd(nprc)   ! Equilibrium particle concentrations of HNO3 (isorropia)
-    REAL :: zcnh3eqae(nbins), zcnh3eqcd(ncld), zcnh3eqpd(nprc)   ! Equilibrium particle concentrations of NH3 (isorropia)
 
     REAL :: zcgnh3eqae(nbins), zcgno3eqae(nbins), &              ! Equilibrium gas concentrations
                 zcgnh3eqcd(ncld), zcgno3eqcd(ncld), &
@@ -2118,31 +1990,27 @@ CONTAINS
     REAL :: zsathno3ae(nbins), zsathno3cd(ncld), zsathno3pd(nprc)
     REAL :: zsatnh3ae(nbins), zsatnh3cd(ncld), zsatnh3pd(nprc)
 
-    REAL :: Hhno3ae(nbins),Hnh3ae(nbins)
-
-    REAL :: zbeta ! LASKE
+    REAL :: zbeta
     REAL :: zdfvap ! Diffusion coefficient for vapors
 
     REAL :: zrh
 
-    REAL :: zhlp1,zhlp2,zhlp3,zhlp4,zhlp5,zhlp6,zhlp7,zhlp8
+    REAL :: zhlp1,zhlp2,zhlp3,zhlp4,zhlp5,zhlp6
 
-    REAL :: adt,adtcae(2,nbins),adtcae2(2,nbins),adtccd(2,ncld),adtcpd(2,nprc) ! Adaptive timestep
+    REAL :: adt,adtcae(2,nbins),adtccd(2,ncld),adtcpd(2,nprc) ! Adaptive timestep
     REAL :: adtc2(2,nbins)
-    REAL :: telp,ttot ! Elapsed time
 
     INTEGER :: nstr
-    INTEGER :: ii,jj,cc,tt
+    INTEGER :: ii,jj,cc
 
     nstr = 1
-    ! ALUSTA KRIITTISET NOLLIKSI
     adtcae(:,:) = 0.
     adtccd(:,:) = 0.
     adtcpd(:,:) = 0.
     adtc2(:,:) = 0.
 
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
 
           zkelno3pd = 1.; zkelno3cd = 1.; zkelno3ae = 1.
           zkelnh3pd = 1.; zkelnh3cd = 1.; zkelnh3ae = 1.
@@ -2236,9 +2104,6 @@ CONTAINS
                          zcgno3eqpd,zcgnh3eqpd,zacno3pd,zacnh3pd,  &
                          zacnh4hso2pd,zachhso4pd,zmolspd           )
 
-
-          !WRITE(*,*) zmolsae(1:7,1)
-
           zsatnh3ae = 1.; zsathno3ae = 1.
           zsatnh3cd = 1.; zsathno3cd = 1.
           zsatnh3pd = 1.; zsathno3pd = 1.
@@ -2257,8 +2122,6 @@ CONTAINS
                zsathno3pd,zsatnh3pd,zmolspd,prlim                                         )
 
           adt = ptstep
-
-          !WRITE(*,*) adt
 
           zhlp1 = SUM( zcno3cae(nstr:nbins) /  &
                (1. + adt*zmtno3ae(nstr:nbins)*zsathno3ae(nstr:nbins)) )
@@ -2317,8 +2180,6 @@ CONTAINS
           zcnh3intcd(1:ncld) = MAX(zcnh3intcd(1:ncld),0.)
           zcnh3intpd(1:nprc) = MAX(zcnh3intpd(1:nprc),0.)
 
-          ! JACOBSONIN RAJOTUS TÄHÄ?
-
           !zcno3int = zcno3tot - SUM(zcno3intae(1:nbins)) - &
           !     SUM(zcno3intcd(1:ncld))  - &
           !     SUM(zcno3intpd(1:nprc))
@@ -2326,9 +2187,6 @@ CONTAINS
           !zcnh3int = zcnh3tot - SUM(zcnh3intae(1:nbins)) - &
           !     SUM(zcnh3intcd(1:ncld))  - &
           !     SUM(zcnh3intpd(1:nprc))
-
-          !WRITE(*,*) zcnh3int, SUM(zcnh3intae(1:nbins))
-          !WRITE(*,*) zsatnh3ae(1:7)
 
           zcno3n = zcno3int
           zcno3nae(:) = zcno3intae(:); zcno3ncd(:) = zcno3intcd(:); zcno3npd(:) = zcno3intpd(:)
@@ -2489,10 +2347,6 @@ CONTAINS
        pgammanh4hso2(cc) = zgammas(6)
        pgammahhso4(cc) = zgammas(7)
 
-       !IF (ppart(cc)%numc < nlim) pmols(cc,:) = 0.
-
-       !WRITE(*,*) pgammano(cc), pgammanh(cc), pgammanh4hso2(cc), pgammahhso4(cc)
-
        pcgno3eq(cc) = zphno3/(rg*ptemp)
        pcgnh3eq(cc) = zpnh3/(rg*ptemp)
 
@@ -2574,8 +2428,6 @@ CONTAINS
     KglNH3 = k03*EXP( a3*zhlp2 + b3*zhlp3 )
     KglHNO3 = k04*EXP( a4*zhlp2 + b4*zhlp3 )
 
-    !WRITE(*,*) 'testi', KllH2O, KllNH3, KglNH3, KglHNO3
-
     ! Get NO3- and H+ molality
     DO cc = 1,nb
 
@@ -2588,10 +2440,6 @@ CONTAINS
           zxi = ( pcnh3(cc) + ppart(cc)%volc(5)*rhoss/mss ) / &
                 ( ppart(cc)%volc(1)*rhosu/msu )
           IF ( zxi <= 2. ) THEN
-             !psathno3(cc) = acthno3(ppart(cc),pachno3(cc),pchno3(cc)) * &
-             !        pkelhno3(cc) / KglHNO3
-             !psatnh3(cc) = actnh3(ppart(cc),pacnh3(cc),pcnh3(cc)) *   &
-             !     pkelnh3(cc) / KglNH3
              ! Molality of SO4
              zhlp1 = pcnh3(cc)*mnh + pchno3(cc)*mno + ppart(cc)%volc(2)*rhooc + &
                   ppart(cc)%volc(5)*rhoss + ppart(cc)%volc(8)*rhowa
@@ -2609,18 +2457,10 @@ CONTAINS
                   ppart(cc)%volc(1)*rhosu + ppart(cc)%volc(8)*rhowa
              zmolna = (ppart(cc)%volc(5)*rhoss/mss)/zhlp1
 
-             !zmolhp = 2.*pmols(cc,4) + pmols(cc,5) + pmols(cc,6) + pmols(cc,7) - &
-             !     (pmols(cc,2) + pmols(cc,3))!2.*zmolso4 + zmolno3 + zmolcl - (zmolnh4 + zmolna)
-
              zmolhp = 2.*zmolso4 + zmolno3 + zmolcl - (zmolnh4 + zmolna)
-
-             !zmolhp = 2.*pmols(cc,4) + pmols(cc,5) + zmolno3 + zmolcl - (zmolnh4 + zmolna)
-
-             !WRITE(*,*) zmolso4, pmols(cc,4), pmols(cc,5),cc
 
           ELSE
 
-             !WRITE(*,*) 'HEP'
              zhlp2 = pkelhno3(cc)*zmolno3*pachno3(cc)**2.
              zmolhp = KglHNO3*pchno3eq(cc)/zhlp2
 
@@ -2636,7 +2476,6 @@ CONTAINS
 
        ELSE
 
-          ! Ei hyvä näin!!!!
           psatnh3(cc) = 0.
           psathno3(cc) = 0.
        END IF
@@ -2729,8 +2568,6 @@ CONTAINS
   !-------------------------------------------------
   REAL FUNCTION coagc(diam1,diam2,mass1,mass2,temp,pres,kernel)
 
-    
-
     USE mo_submctl, ONLY : pi, pi6, boltz, pstand, grav
     USE mo_constants, ONLY : rd, amd
 
@@ -2749,8 +2586,6 @@ CONTAINS
                                   !                            2 - hydrometeor-aerosol or hydrometeor-hydrometeor coagulation
 
     !-- Output variables ---------
-    !REAL ::  &
-    !     coagc       ! coagulation coefficient of particles [m3/s]
 
     !-- Local variables ----------
     REAL ::  &
@@ -2782,15 +2617,12 @@ CONTAINS
          flux        ! flux in continuum and free molec. regime [m/s]
 
 
-    REAL, DIMENSION(2) ::  &
-         schm,   &   ! Schmidt nubmer
-         reyn        ! Reynolds number
-    REAL :: &
-         stok        ! Stokes number
-    INTEGER :: lrg,sml
-
-    INTEGER :: i
-    REAL :: rhoref ! reference density in STP conditions
+    REAL ::  &
+         schm(2), &   ! Schmidt nubmer
+         reyn(2), &    ! Reynolds number
+         stok             ! Stokes number
+    REAL :: rhoref               ! Reference air density in STP conditions
+    INTEGER :: lrg,sml,i
 
     zbrown = 0.
     zbrconv = 0.
@@ -2798,7 +2630,7 @@ CONTAINS
     zev = 0.
     coagc = 0.
 
-    rhoref =  1.01325e5/(287.*273.15)
+    rhoref = 1.01325e5/(287.*273.15)
 
     !-------------------------------------------------------------------------------
 
@@ -2806,8 +2638,7 @@ CONTAINS
     diam = (/ diam1, diam2 /)       ! particle diameters [m]
     mpart = (/ mass1, mass2 /)       ! particle masses [kg]
 
-    visc = (7.44523e-3*temp**1.5)/ &
-         (5093.*(temp+110.4))                   ! viscosity of air [kg/(m s)]
+    visc = (7.44523e-3*temp**1.5)/(5093.*(temp+110.4)) ! viscosity of air [kg/(m s)]
 
     mfp = (1.656e-10*temp+1.828e-8)*pstand/pres ! mean free path of air [m]
 
@@ -2846,7 +2677,7 @@ CONTAINS
     SELECT CASE(kernel)
        CASE(1)
 
-          ! Aerosol-Aerosol coagulation - like the original version
+          ! Aerosol-Aerosol coagulation - like the f version
           !-- 5) Coagulation coefficient [m3/s] -------------------------------------
           coagc = flux(1) / (mdiam/(mdiam+fmdist) + flux(1)/flux(2))
 

--- a/src/src_salsa/mo_salsa_init.f90
+++ b/src/src_salsa/mo_salsa_init.f90
@@ -59,9 +59,6 @@ CONTAINS
 
   SUBROUTINE set_sizebins()
 
-    
-
-    ! POISTA MITÄ EI TARVII
     USE mo_submctl, ONLY : &
          pi6,         & ! pi/6
          reglim,      & ! diameter limits for size regimes [m]
@@ -71,11 +68,10 @@ CONTAINS
          in2b, fn2b,  & !     - " -       2b
          nbin2, nbin3,& !
          nbins,  &
-         sigma,  &
          aerobins
 
     USE mo_salsa_driver, ONLY : &
-         kbdim,kproma,klev,  &
+         kbdim,klev,  &
          aero
 
     IMPLICIT NONE
@@ -83,10 +79,7 @@ CONTAINS
     !-- local variables ----------
     INTEGER :: ii, jj,cc,dd,vv ! loop indices
 
-    REAL ::  &
-         ratio,  & ! ratio of regime upper and lower diameter
-         vlo,    & !
-         vhi
+    REAL ::  ratio ! ratio of regime upper and lower diameter
 
     ! -------------------------
     ! Allocate aerosol tracers
@@ -97,7 +90,7 @@ CONTAINS
     !-------------------------------------------------------------------------------
 
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
 
           !-- 1) size regime 1: --------------------------------------
           !  - minimum & maximum *dry* volumes [fxm]
@@ -187,8 +180,6 @@ CONTAINS
   !---------------------------------------------------------------------------
 
   SUBROUTINE set_cloudbins()
-    
-    !POISTA MITÄ EI TARVII
     USE mo_submctl, ONLY : pi6,             &
                                ica,icb,         &
                                fca,fcb,         &
@@ -200,7 +191,7 @@ CONTAINS
                                in2b,fn2b,       &
                                cloudbins,       &
                                precpbins
-    USE mo_salsa_driver, ONLY : kproma, kbdim, klev, &
+    USE mo_salsa_driver, ONLY : kbdim, klev, &
                                  cloud,precp,aero
 
     IMPLICIT NONE
@@ -214,13 +205,11 @@ CONTAINS
     INTEGER :: armin(1)
     LOGICAL :: l_min(fn2a)
 
-    REAL :: tmplolim(7), tmphilim(7), tmpmid(7)
+    REAL :: tmplolim(7), tmphilim(7)
 
     ! Helper arrays to set up precipitation size bins
     tmplolim = (/50.,55.,65.,100.,200.,500.,1000./)*1.e-6
     tmphilim = (/55.,65.,100.,200.,500.,1000.,2000./)*1.e-6
-
-    armin = 0
 
     ! For setting cloud droplet bins
     DO ii = in1a,fn2a
@@ -269,7 +258,7 @@ CONTAINS
     ALLOCATE(cloud(kbdim,klev,ncld), precp(kbdim,klev,nprc))
 
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
 
           ! -------------------------------------------------
           ! Set cloud properties (parallel to aerosol bins)
@@ -356,8 +345,6 @@ CONTAINS
   !
   !---------------------------------------------------------------------------
   SUBROUTINE set_icebins()
-    
-    !POISTA MITÄ EI TARVII
     USE mo_submctl, ONLY : pi6,             &
                                iia,iib,         &
                                fia,fib,         &
@@ -369,33 +356,25 @@ CONTAINS
                                in2b,fn2b,       &
                                icebins,         &
                                snowbins
-    USE mo_salsa_driver, ONLY : kproma, kbdim, klev, &
-                                 ice,snow,aero !!huomhuom tarviiko myös aero?
-
+    USE mo_salsa_driver, ONLY : kbdim, klev, &
+                                 ice,snow,aero
 
     IMPLICIT NONE
 
     INTEGER :: ii,jj,cc,bb
 
-    ! For ice bins !! huomhuom ilmeisesti voi apinoida suoraan??
+    ! For ice bins
     REAL :: zvoldiff(fn2a)
     INTEGER :: zindex(fn2a)
     INTEGER :: imin, nba,nbb
     INTEGER :: armin(1)
     LOGICAL :: l_min(fn2a)
 
-    REAL :: tmplolim(7), tmphilim(7), tmpmid(7)
+    REAL :: tmplolim(7), tmphilim(7)
 
-    !!huomhuom näillä alkuun, todelliset arvot myöhemmin, alaraja kriittisempi #arvo
-    ! Helper arrays to set up ice size bins
+    ! Helper arrays to set up snow size bins
     tmplolim = (/50.,55.,65., 100.,200.,500., 1000./)*1.e-6
     tmphilim = (/55.,65.,100.,200.,500.,1000.,2000./)*1.e-6
-!    tmplolim = (/1.,3., 13.,50., 190.,720., 2700./)*1.e-6
-!    tmphilim = (/3.,13.,50.,190.,720.,2700.,10000./)*1.e-6
-
-
-
-    armin = 0
 
     ! For setting ice particle bins
     DO ii = in1a,fn2a
@@ -444,7 +423,7 @@ CONTAINS
     ALLOCATE(ice(kbdim,klev,nice), snow(kbdim,klev,nsnw))
 
     DO jj = 1,klev
-       DO ii = 1,kproma
+       DO ii = 1,kbdim
 
           ! -------------------------------------------------
           ! Set iceproperties (parallel to aerosol bins) !!!huomhuom tehdäänkö jäälle myös näin?
@@ -521,89 +500,8 @@ CONTAINS
     END DO
     snowbins = 0.5*snowbins ! To radius
 
-
   END SUBROUTINE set_icebins
 
-
-  ! fxm: is it really the upper limit of the particles that we want to
-  !  use as a criterion? how about supersat of 0.5%.
-  !*********************************************************************
-  !
-  !  subroutine ACTCURVE()
-  !
-  !*********************************************************************
-  !
-  ! Purpose:
-  ! --------
-  ! Calculates the criterion based on which particles from
-  !  insoluble sections are moved into soluble sections
-  !
-  !
-  ! Method:
-  ! -------
-  ! Critical dry volume ratio of soluble matter calculated at
-  !  upper volume boundary (in regime 3: fixed bin volume) of each bin
-  !
-  ! A fixed critical saturation ratio assumed for this calculation
-  !
-  ! NB! The critical soluble fraction is calculated according to
-  !  sulphate properties
-  !
-  !
-  ! Interface:
-  ! ----------
-  ! Called from model driver
-  ! (only at the beginning of simulation)
-  !
-  !
-  ! Coded by:
-  ! ---------
-  ! Hannele Korhonen (FMI) 2005
-  !
-  ! Juha Tonttila (FMI) 2014: Updated for the new aerosol datatype
-  !
-  !----------------------------------------------------------------------
-
-  SUBROUTINE actcurve()
-
-    USE mo_submctl, ONLY: &
-         pi,        &
-         pi6,       & ! pi/6
-         rg,        & ! universal gas constant [J/(mol K)]
-         in1a,fn2b, & ! size bin indices
-         mwa,       & ! molar mass of water [kg/mol]
-         rhowa,     & ! density of water [kg/m3]
-         surfw0,    & ! surface tension of water [J/m2]
-         msu,       & ! molar mass of sulphate [kg/mol]
-         rhosu,     & ! density of sulphate [kg/m3]
-         ions,      & ! van t'Hoff factor
-         slim,      & ! critical saturation value
-         epsv         ! critical volume ratio of soluble material (*temp**3)
-
-    USE  mo_salsa_driver, ONLY : &
-         aero
-
-    IMPLICIT NONE
-
-    !-- local variables ------
-    REAL :: aa, bb   ! constants in K?hler equation
-
-    !--------------------------------------------------------------------
-
-    aa = 4.*mwa*surfw0/(rg*rhowa)   ! curvature (Kelvin) effect
-    bb = 6.*mwa*ions*rhosu/(pi*rhowa*msu) ! solute (Raoult) effect
-
-    !-- Calculation of critical soluble material in each bin
-    !   (must be divided with temp**3 when used) ------------------
-    !
-    !TB changed the calculation of  maximum soluble fraction from
-    !   high volume limit to mean diameter
-    !
-
-    !    epsv(in1a:fn2b) = 4.*aa**3/(27.*bb*(log(slim))**2*vhilim(in1a:fn2b))
-    epsv(in1a:fn2b) = 4.*aa**3/(27.*bb*(log(slim))**2*(pi6*aero(1,1,in1a:fn2b)%dmid**3))
-
-  END SUBROUTINE actcurve
 
 
   !----------------------------------------------------------------------
@@ -620,7 +518,6 @@ CONTAINS
   !----------------------------------------------------------------------
   SUBROUTINE define_salsa()
 
-    
     USE mo_submctl, ONLY : nlcoag,                &
                                nlcgaa,nlcgcc,nlcgpp,  &
                                nlcgca,nlcgpa,nlcgpc,  &
@@ -745,18 +642,10 @@ CONTAINS
     !
     !-------------------------------------------------------------------------------
 
-    
-    USE mo_submctl, ONLY : reglim, nbin, nbin2, nbin3,     &
+    USE mo_submctl, ONLY : nbin, nbin2, nbin3,     &
                                in1a,fn1a,in2a,fn2a,in2b,fn2b,  &
-                               nbins,                          &
-
-                               epsv,sigma,csr_strat_wat,csr_strat_mix, &
-                               csr_strat_ice,csr_conv,zbcr,             &
-
-                               cfracn,zfracn,zfracn_cv,massacc,          &
-                               iso4b,inob,inhb,iocb,ibcb,idub,issb
-
-    USE mo_salsa_driver, ONLY : kproma,kbdim
+                               nbins, &
+                               massacc
 
     IMPLICIT NONE
 
@@ -777,16 +666,10 @@ CONTAINS
     nbins = fn2b
 
     ! --2) Allocate arrays
-    ALLOCATE(epsv(nbins), &
-             sigma(fn2b),csr_strat_wat(fn2b),csr_strat_mix(fn2b),     &
-             csr_strat_ice(fn2b),csr_conv(fn2b),zbcr(fn2b)                        )
 
-    ALLOCATE(cfracn(fn2b),zfracn(fn2b),zfracn_cv(fn2b),massacc(nbins))
+    ALLOCATE(massacc(nbins))
 
     massacc = 1.
-
-    ! Tarvitaanko näitä??
-    ALLOCATE(iso4b(fn2b),inob(fn2b),inhb(fn2b),iocb(fn2b),ibcb(fn2b),idub(fn2b),issb(fn2b))
 
 
     ! -- Aerosol tracers are allocated in *set_sizebins*
@@ -798,8 +681,6 @@ CONTAINS
     CALL set_cloudbins()
 
     CALL set_icebins()
-
-    CALL actcurve()
 
   END SUBROUTINE salsa_initialize
 

--- a/src/src_salsa/mo_salsa_init.f90
+++ b/src/src_salsa/mo_salsa_init.f90
@@ -531,7 +531,7 @@ CONTAINS
                                nlauto,nlautosnow,     &
                                nlactiv,               &
                                nlactintst,            &
-							   nlactbase,			  &
+                               nlactbase,            &
                                nlichom,               &
                                nlichet,               &
                                nlicimmers,            &
@@ -601,14 +601,14 @@ CONTAINS
          volDistB,      & ! Same as above but for b-bins
          nf2a,          & ! Number fraction of particles allocated to a-bins in regime 2. b-bins will get 1-nf2a
 
-	     ! ------------
-	     ! -- Juha: These should eventually be replaced with physical processing !!!! Dont use for liquid clouds!
+         ! ------------
+         ! -- Juha: These should eventually be replaced with physical processing !!!! Dont use for liquid clouds!
          initliqice,  & ! initialize ice and liquid cloud particles from aerosol bins
          liqFracA,      & ! fraction of aerosols that are activated to liquid cloud droplets in A bins
          iceFracA,      & ! fraction of aerosols that are activated to ice cloud particles in A bins
          liqFracB,      & ! fraction of aerosols that are activated to liquid cloud droplets  in B bins
          iceFracB,      & ! fraction of aerosols that are activated to    ice cloud particles in B bins
-	     ! ---------------------------------------------------------------------------------------------------		
+         ! ---------------------------------------------------------------------------------------------------
          rhlim,         & ! Upper limit RH/100 for sals during initialization and spinup 
 
          sigmag,        & ! Stdev for the 7 initial lognormal modes

--- a/src/src_salsa/mo_salsa_nucleation.f90
+++ b/src/src_salsa/mo_salsa_nucleation.f90
@@ -91,7 +91,7 @@ CONTAINS
          avog,                   &
          rg,                     &
          pi,                     &
-		 reglim
+         reglim
 
     IMPLICIT NONE
 
@@ -970,10 +970,10 @@ CONTAINS
     REAL :: &
          zlnj     ! logarithm of nucleation rate
 
-	!------------------------------------------------------------------------------------------------
-	! loops over
-	DO jj = 1,klev !  vertical grid
-		DO ii = 1,kbdim !  horizontal kbdim in the slab
+    !------------------------------------------------------------------------------------------------
+    ! loops over
+    DO jj = 1,klev !  vertical grid
+        DO ii = 1,kbdim !  horizontal kbdim in the slab
 
           !-- 1) Checking that we are in the validity range of the parameterization -----------
           ! validity of parameterization : DO NOT REMOVE!
@@ -1207,7 +1207,7 @@ CONTAINS
      !    DO jj = 1,klev !  vertical grid
      !       DO ii = 1,kbdim !  horizontal kbdim in the slab
      !          pnuc_rate(ii,jj) = 1.e-7*psa_conc(ii,jj) ! [#/(m3 s)]
-     !	   END DO
+     !       END DO
      !    END DO
      !    pd_crit = 7.9375e-10 ! [m]
 
@@ -1242,7 +1242,7 @@ CONTAINS
    ! ---------------------------------------------------------------
 
    SUBROUTINE orgnucl(kproma,     kbdim,        klev,            &
-		      pc_org,     pnuc_rate,    pd_crit, ppbl,   &
+              pc_org,     pnuc_rate,    pd_crit, ppbl,   &
                       pn_crit_sa, pn_crit_ocnv, pk_sa,   pk_ocnv)
 
      IMPLICIT NONE

--- a/src/src_salsa/mo_salsa_nucleation.f90
+++ b/src/src_salsa/mo_salsa_nucleation.f90
@@ -341,7 +341,7 @@ CONTAINS
     !-- 2) Change of particle and gas concentrations ------------------------------------
     ! loops over
     DO jj = 1,klev !  vertical grid
-       DO ii = 1,kproma !  horizontal kproma in the slab
+       DO ii = 1,kbdim !  horizontal kbdim in the slab
 
 !          !-- very small nucleation rates neglected
 !          IF (zjnuc(ii,jj) < 1.e3) CYCLE
@@ -683,8 +683,6 @@ CONTAINS
                      pnuc_rate, pn_crit_sa, pn_crit_ocnv, pd_crit, &
                      ppbl,      pk_sa,      pk_ocnv)
 
-    
-
     USE mo_submctl, ONLY : rg, pi, avog
 
     IMPLICIT NONE
@@ -732,7 +730,7 @@ CONTAINS
     zpbl(:) = ppbl(:)
     if (lnuctropo) then
 
-       DO ii = 1,kproma !  horizontal kproma in the slab
+       DO ii = 1,kbdim !  horizontal kbdim in the slab
           DO jj = 1,zpbl(ii) !  vertical grid
              !-- 1) Checking that we are in the validity range of the parameterization -----------
 
@@ -944,8 +942,6 @@ CONTAINS
                      pnuc_rate, pn_crit_sa, pn_crit_ocnv, pd_crit, &
                      pk_sa,     pk_ocnv)
 
-    
-
     IMPLICIT NONE
     !-- Input variables -------------------
     INTEGER, INTENT(IN) ::       &
@@ -977,7 +973,7 @@ CONTAINS
 	!------------------------------------------------------------------------------------------------
 	! loops over
 	DO jj = 1,klev !  vertical grid
-		DO ii = 1,kproma !  horizontal kproma in the slab
+		DO ii = 1,kbdim !  horizontal kbdim in the slab
 
           !-- 1) Checking that we are in the validity range of the parameterization -----------
           ! validity of parameterization : DO NOT REMOVE!
@@ -1126,8 +1122,6 @@ CONTAINS
                      pnuc_rate,  pd_crit,      ppbl,          &
                      pn_crit_sa, pn_crit_ocnv, pk_sa, pk_ocnv)
 
-     
-
      IMPLICIT NONE
 
      !-- Input variables -------------------
@@ -1158,7 +1152,7 @@ CONTAINS
      zpbl(:)=ppbl(:)
 
      ! loops over
-     DO ii = 1,kproma !  horizontal kproma in the slab
+     DO ii = 1,kbdim !  horizontal kbdim in the slab
         DO jj = zpbl(ii),klev !  vertical grid
 
            !  pnuc_rate(ii,jj) = 1.19386e-17*sqrt(ptemp(ii,jj))*pc_sa(ii,jj)**2 ! [#/(m3 s)]
@@ -1182,8 +1176,6 @@ CONTAINS
    SUBROUTINE actnucl(kproma,     kbdim,        klev,                   &
                       psa_conc,   pnuc_rate,    pd_crit, ppbl,          &
                       pn_crit_sa, pn_crit_ocnv, pk_sa,   pk_ocnv, activ)
-
-     
 
      IMPLICIT NONE
 
@@ -1213,7 +1205,7 @@ CONTAINS
      ! loops over
      !  previous loop structure
      !    DO jj = 1,klev !  vertical grid
-     !       DO ii = 1,kproma !  horizontal kproma in the slab
+     !       DO ii = 1,kbdim !  horizontal kbdim in the slab
      !          pnuc_rate(ii,jj) = 1.e-7*psa_conc(ii,jj) ! [#/(m3 s)]
      !	   END DO
      !    END DO
@@ -1221,7 +1213,7 @@ CONTAINS
 
      zpbl(:)=ppbl(:)
 
-     DO ii = 1,kproma !  horizontal kproma in the slab
+     DO ii = 1,kbdim !  horizontal kbdim in the slab
         DO jj = zpbl(ii),klev !  vertical grid
            !  gone through for boundary layer klev only!
            ! act_coeff 1e-7 by default, namelist controllable.
@@ -1252,8 +1244,6 @@ CONTAINS
    SUBROUTINE orgnucl(kproma,     kbdim,        klev,            &
 		      pc_org,     pnuc_rate,    pd_crit, ppbl,   &
                       pn_crit_sa, pn_crit_ocnv, pk_sa,   pk_ocnv)
-
-     
 
      IMPLICIT NONE
 
@@ -1286,7 +1276,7 @@ CONTAINS
      !-------------------------------------
      zpbl(:)=ppbl(:)
      ! loops over
-     DO ii = 1,kproma !  horizontal kproma in the slab
+     DO ii = 1,kbdim !  horizontal kbdim in the slab
         DO jj = zpbl(ii),klev !  vertical grid
            pnuc_rate(ii,jj) = Aorg*pc_org(ii,jj)
            !          pnuc_rate(ii,jj) = Korg*pc_org(ii,jj)**2       ! homomolecular nuleation - which one?
@@ -1316,8 +1306,6 @@ CONTAINS
    SUBROUTINE sumnucl(kproma,     kbdim,        klev,                     &
                       pc_sa,      pc_org,       pnuc_rate, pd_crit, ppbl, &
                       pn_crit_sa, pn_crit_ocnv, pk_sa,     pk_ocnv)
-
-     
 
      IMPLICIT NONE
 
@@ -1350,7 +1338,7 @@ CONTAINS
 
      !-------------------------------------
      zpbl(:)=ppbl(:)
-     DO ii = 1,kproma !  horizontal kproma in the slab
+     DO ii = 1,kbdim !  horizontal kbdim in the slab
         DO jj = zpbl(ii),klev !  vertical grid
            pnuc_rate(ii,jj) = As1*pc_sa(ii,jj)+As2*pc_org(ii,jj) ![#/m3/s]
 
@@ -1380,8 +1368,6 @@ CONTAINS
                       pc_sa,      pc_org,                      &
                       pnuc_rate,  pd_crit,      ppbl,          &
                       pn_crit_sa, pn_crit_ocnv, pk_sa, pk_ocnv)
-
-     
 
      IMPLICIT NONE
 
@@ -1413,7 +1399,7 @@ CONTAINS
 
      !-------------------------------------
      zpbl(:)=ppbl(:)
-     DO ii = 1,kproma         !  horizontal kproma in the slab
+     DO ii = 1,kbdim         !  horizontal kbdim in the slab
         DO jj = zpbl(ii),klev !  vertical grid
            pnuc_rate(ii,jj) = zKhet*pc_sa(ii,jj)*pc_org(ii,jj)*1.E6 ![#/m3/s]
 
@@ -1445,8 +1431,6 @@ CONTAINS
                      pnuc_rate,  pd_crit,      ppbl,          &
                      pn_crit_sa, pn_crit_ocnv, pk_sa, pk_ocnv)
 
-     
-
      IMPLICIT NONE
 
      !-- Input variables -------------------
@@ -1477,7 +1461,7 @@ CONTAINS
 
      !-------------------------------------
      zpbl(:)=ppbl(:)
-     DO ii = 1,kproma !  horizontal kproma in the slab
+     DO ii = 1,kbdim !  horizontal kbdim in the slab
         DO jj = zpbl(ii),klev !  vertical grid
            pnuc_rate(ii,jj) = (zKsa1*pc_sa(ii,jj)**2 + zKsa2*pc_sa(ii,jj)*pc_org(ii,jj))*1.E6 ![#/m3/s]
 
@@ -1506,8 +1490,6 @@ CONTAINS
                         pc_sa,      pc_org,                      &
                         pnuc_rate,  pd_crit,      ppbl,          &
                         pn_crit_sa, pn_crit_ocnv, pk_sa, pk_ocnv)
-
-     
 
      IMPLICIT NONE
 
@@ -1538,7 +1520,7 @@ CONTAINS
      REAL :: zKs1 = 0.92e-14, zKs2 = 7.0e-14, zKs3 = 0.098e-14 ![cm3/s] (Paasonen et al. Table 3.)
      !-------------------------------------
      zpbl(:)=ppbl(:)
-     DO ii = 1,kproma !  horizontal points in the slab
+     DO ii = 1,kbdim !  horizontal points in the slab
         DO jj = zpbl(ii),klev !  vertical grid
            pnuc_rate(ii,jj) = (zKs1*pc_sa(ii,jj)**2 + &
                 zKs2*pc_sa(ii,jj)*pc_org(ii,jj)+ zKs3*pc_org(ii,jj)**2)*1.E6  ![#/m3/s]

--- a/src/src_salsa/mo_salsa_properties.f90
+++ b/src/src_salsa/mo_salsa_properties.f90
@@ -1,5 +1,5 @@
 !****************************************************************
-!*	                                                        *
+!*                                                            *
 !*   module MO_SALSA_PROPERTIES                                 *
 !*                                                              *
 !*   Contains subroutines and functions that are used           *
@@ -211,10 +211,7 @@ CONTAINS
                    !-- Kelvin effect 
                    
                    count = count + 1
-                   IF (count > 1000) THEN
-                      WRITE(*,*) 'SALSA properties: no convergence!!'
-                      EXIT
-                   END IF
+                   IF (count > 1000) STOP 'SALSA equilibration (regime 1): no convergence!!'
 
                 END DO
 
@@ -322,10 +319,7 @@ CONTAINS
                       zke = exp(2.*surfw0*mvsu/(boltz*ptemp(ii,jj)*zdwet))
 
                       count = count + 1
-                      IF (count > 1000) THEN
-                         WRITE(*,*) 'SALSA properties: no convergence!!'
-                         EXIT
-                      END IF
+                      IF (count > 1000) STOP 'SALSA equilibration (regime 2): no convergence!!'
                       
                    END DO
 

--- a/src/src_salsa/mo_salsa_properties.f90
+++ b/src/src_salsa/mo_salsa_properties.f90
@@ -76,8 +76,8 @@ CONTAINS
          t_section,    &
          pi6,          & ! pi/6
          in1a, fn1a,   &
-         in2a, fn2a,   &
-         in2b, fn2b,   &
+         in2a,    &
+         fn2b,   &
          boltz,        & ! Boltzmann constant [J/K]
          nlim,         & ! lowest possible particle conc. in a bin [#/m3]
     
@@ -97,9 +97,6 @@ CONTAINS
          rhoss, mss,   &
          rhono, mno,   &
          rhonh, mnh
-
-
-    
 
     IMPLICIT NONE
 
@@ -146,10 +143,9 @@ CONTAINS
     !-- 1) Regime 1: sulphate and partly water-soluble OC -----------------
     !                This is done for every CALL
     zke = 1.001
-    !pdwet = 0.
     DO kk = in1a,fn1a      ! size bin
        DO jj = 1,klev      ! vertical grid
-          DO ii = 1,kproma ! horizontal grid
+          DO ii = 1,kbdim ! horizontal grid
 
              !-- initialize
              zbinmol = 0.
@@ -224,7 +220,6 @@ CONTAINS
 
                 ! Instead of lwc, use the volume concentration of water from now on 
                 ! (easy to convert...)
-                !plwc(ii,jj,kk) = zlwc
                 paero(ii,jj,kk)%volc(8) = zlwc/rhowa
                 
                 ! If this is initialization, update the core and wet diameter
@@ -255,7 +250,7 @@ CONTAINS
        ! loops over:
        DO kk = in2a,fn2b      ! size bin
           DO jj = 1,klev      ! vertical grid
-             DO ii = 1,kproma ! horizontal grid
+             DO ii = 1,kbdim ! horizontal grid
 
                 zke = 1.02
             
@@ -355,6 +350,10 @@ CONTAINS
   END SUBROUTINE equilibration
 
   ! Juha: It should not be necessary to do this since cloud water content is Always calculated via condensation equations
+  !               - This is done only for initialization call, otherwise the
+  !                 water contents are computed via condensation
+  !               - Not an equilibrium, but fixed droplet/ice diameter
+  !               - Regimes 2a & 2b for ice and cloud droplets
   ! ----------------------------------------------------------------------------------------------------------------------
   SUBROUTINE equilibration_cloud(kproma, kbdim, klev,    &
                            prh, ptemp, pcloud, pice )
@@ -362,34 +361,10 @@ CONTAINS
     USE mo_submctl, ONLY : &
          t_section,    &
          pi6,          & ! pi/6
-         ica, fca,     &
-         icb, fcb,     &
-         iia, fia,     &
-         iib, fib,     &
+         ica, fcb,     &
+         iia, fib,     &
          ncld,nice,  &
-         boltz,        & ! Boltzmann constant [J/K]
-         nlim,         & ! lowest possible particle conc. in a bin [#/m3]
-
-                         ! molar masses [kg/mol]
-         mwa,          & ! water
-                         ! molecular volumes [m3]
-         mvsu,         & ! sulphate
-                         ! density [kg/m3]
-         rhowa,        & ! water
-
-         surfw0,       & ! surface tension of water [J/m2]
-         epsoc,        & ! fxm
-
-         rhosu, msu,   & ! properties of compounds
-         rhooc, moc,   &
-         rhobc, mbc,   &
-         rhoss, mss,   &
-         rhono, mno,   &
-         rhonh, mnh,   &
-         rhoic
-
-
-    
+         nlim, prlim
 
     IMPLICIT NONE
 
@@ -403,86 +378,44 @@ CONTAINS
          prh(kbdim,klev),          & ! relative humidity [0-1]
          ptemp(kbdim,klev)           ! temperature [K]
 
-
     !-- output variables -------------
     TYPE(t_section), INTENT(inout) :: pcloud(kbdim,klev,ncld), &
                                       pice(kbdim,klev,nice)
 
-
-
     !-- local variables --------------
     INTEGER :: ii, jj, kk             ! loop indices
 
-
-    !-- 2) Regime 2a & 2b: sulphate, OC, BC and sea salt ----------------------------
-    !                 This is done only for initialization call, otherwise the
-    !                 water contents are computed via condensation
-
-
-       ! loops over:
-       DO kk = ica%cur,fcb%cur      ! size bin
-          DO jj = 1,klev      ! vertical grid
-             DO ii = 1,kproma ! horizontal grid
-
-
-
-                !-- 1) particle properties calculated for non-empty bins ---------
+    DO jj = 1,klev      ! vertical grid
+        DO ii = 1,kbdim ! horizontal grid
+            ! Cloud droplets
+            DO kk = ica%cur,fcb%cur      ! size bin
                 IF ((pcloud(ii,jj,kk)%numc > nlim)) THEN
-
-
-                   ! Liquid water content; instead of LWC use the volume concentration
-
+                   !-- 1) particle properties calculated for non-empty bins ---------
                    pcloud(ii,jj,kk)%volc(8) = pi6*12.0E-6**3*pcloud(ii,jj,kk)%numc ! set water content according to 12um diameter
-
                    pcloud(ii,jj,kk)%dwet = 11.0E-6
                    pcloud(ii,jj,kk)%core = pi6*pcloud(ii,jj,kk)%dmid**3
-
-
-
                 ELSE
-                   !-- 2.2) empty bins given bin average values -------------------------
+                   !-- 2) empty bins given bin average values -------------------------
                    pcloud(ii,jj,kk)%dwet = pcloud(ii,jj,kk)%dmid
                    pcloud(ii,jj,kk)%core = pi6*pcloud(ii,jj,kk)%dmid**3
                 END IF
+            ENDDO
 
-             END DO
-          END DO
-       END DO
-
-!!!!!!*******************************************************************************'
-!!!!!! ice bins
-!!!!!!**************************************************************
-    !-- 2) Regime 2a & 2b: sulphate, OC, BC and sea salt ----------------------------
-    !                 This is done only for initialization call, otherwise the
-    !                 water contents are computed via condensation
-
-
-       ! loops over:
-       DO kk = iia%cur,fib%cur      ! size bin
-          DO jj = 1,klev      ! vertical grid
-             DO ii = 1,kproma ! horizontal grid
-
-
-
-                !-- 1) particle properties calculated for non-empty bins ---------
-                IF ((pice(ii,jj,kk)%numc > nlim)) THEN
-
-
+            ! Ice
+            DO kk = iia%cur,fib%cur      ! size bin
+                IF ((pice(ii,jj,kk)%numc > prlim)) THEN
+                    !-- 1) particle properties calculated for non-empty bins ---------
                    pice(ii,jj,kk)%volc(8) = pi6*30.0E-6**3*pice(ii,jj,kk)%numc  ! set water content according to 30um diameter
                    pice(ii,jj,kk)%dwet = 30.0E-6! sqrt(3*B/A)
-
                    pice(ii,jj,kk)%core = pi6*pice(ii,jj,kk)%dmid**3
-
-
                 ELSE
-                   !-- 2.2) empty bins given bin average values -------------------------
+                   !-- 2) empty bins given bin average values -------------------------
                    pice(ii,jj,kk)%dwet = pice(ii,jj,kk)%dmid
                    pice(ii,jj,kk)%core = pi6*pice(ii,jj,kk)%dmid**3
                 END IF
-
-             END DO
-          END DO
-       END DO
+            END DO
+        END DO
+    END DO
 
   END SUBROUTINE equilibration_cloud
 

--- a/src/src_salsa/mo_salsa_sizedist.f90
+++ b/src/src_salsa/mo_salsa_sizedist.f90
@@ -10,14 +10,9 @@ CONTAINS
          pi6,                       &
          pi,                        &
          in1a,                      &
-         in2b,                      &
-         fn2a,                      &
-         fn2b, listspec
+         fn2b
 
     USE mo_salsa_driver, ONLY : aero ! This is needed for size bins spacings
-!    USE grid, ONLY : prtcl !! this should be avoided ! #mod
-    
-!    USE class_componentIndex, ONLY : IsUsed !#mod
     IMPLICIT NONE
 
     INTEGER, PARAMETER :: nmod = 7
@@ -46,9 +41,9 @@ CONTAINS
     naero = 0.
 
     DO jj = 1,klev    ! vertical grid
-       DO ii = 1,kproma ! horizontal grid
+       DO ii = 1,kbdim ! horizontal grid
 
-          DO kk = in1a, fn2a
+          DO kk = in1a, fn2b
              naero(ii,jj,kk) = 0.0
 
              d1 = (aero(ii,jj,kk)%vlolim/pi6)**(1./3.)
@@ -60,55 +55,18 @@ CONTAINS
                 dmid=(d1+d2)/2
                 deltadp = log(d2/d1)
                 
-                !deltadp = (aero(ii,jj,kk)%vhilim**(1./3.)-aero(ii,jj,kk)%vlolim**(1./3.))/   &
-                !     pi6**(1./3.)
-                
                 !-- size distribution
                 !   ntot = total number, total area, or total volume concentration
                 !   dpg = geometric-mean number, area, or volume diameter
                 !   n(kk) = number, area, or volume concentration in a bin
-!                naero(ii,jj,kk) = naero(ii,jj,kk)+sum(n*deltadp/                        &
-!                     (sqrt(2.*pi)*log(sigmag))*                 &
-!                     exp(-log(aero(ii,jj,kk)%dmid/dpg)**2/(2.*log(sigmag)**2)))
-                  naero(ii,jj,kk) = naero(ii,jj,kk)+sum(n*deltadp/                        &
+                naero(ii,jj,kk) = naero(ii,jj,kk)+sum(n*deltadp/                        &
                      (sqrt(2.*pi)*log(sigmag))*                 &
                      exp(-log(dmid/dpg)**2/(2.*log(sigmag)**2)))
-                
-
- !                write(*,*) naero(ii,jj,kk)*1e-6,d1,d2,dmid
              END DO
- !            write(*,*) dpg(1:2),n(1:2)*1e-6
- !            write(*,*) kk,naero(ii,jj,kk)*1e-6,aero(ii,jj,kk)%dmid, (aero(ii,jj,kk)%vlolim/pi6)**(1./3.), &
- !                 (aero(ii,jj,kk)%vhilim/pi6)**(1./3.)
- !            write(*,*) sum(naero(ii,jj,:))
- !            write(*,*) 'here'
- !            pause
-          END DO
 
-          IF ( ANY( listspec=='BC' ) .OR. ANY( listspec=='DU' ) ) THEN
-          ! insolubles
-            DO kk = in2b, fn2b !!! #mod
+           END DO
 
-             d1 = (aero(ii,jj,kk)%vlolim/pi6)**(1./3.)
-             d2 = (aero(ii,jj,kk)%vhilim/pi6)**(1./3.)
-
-             deltadp = log(d2/d1)
-
-             !deltadp = (aero(ii,jj,kk)%vhilim**(1./3.)-aero(ii,jj,kk)%vlolim**(1./3.))/   &
-             !     pi6**(1./3.)
-
-             !-- size distribution
-             !   ntot = total number, total area, or total volume concentration
-             !   dpg = geometric-mean number, area, or volume diameter
-             !   n(kk) = number, area, or volume concentration in a bin
-             naero(ii,jj,kk) = sum(n*deltadp/                        &
-                  (sqrt(2.*pi)*log(sigmag))*                 &
-                  exp(-log(aero(ii,jj,kk)%dmid/dpg)**2/(2.*log(sigmag)**2)))
-
-            END DO
-          END IF
        END DO
-
     END DO
 
   END SUBROUTINE size_distribution

--- a/src/src_salsa/mo_salsa_update.f90
+++ b/src/src_salsa/mo_salsa_update.f90
@@ -15,9 +15,9 @@ MODULE mo_salsa_update
 
 CONTAINS
 
-  SUBROUTINE distr_update(kproma,	kbdim, 	klev,   	&
-                          paero,	pcloud, pprecp , 	&
-                          pice,  	psnow,  level 		)
+  SUBROUTINE distr_update(kproma, kbdim, klev, &
+                          paero, pcloud, pprecp, &
+                          pice, psnow, level )
 
     USE mo_submctl
     
@@ -109,7 +109,7 @@ CONTAINS
                    !zvfrac = znfrac * zVexc / (1./2.*(zVihi+zVilo))
                    zvfrac = MIN(0.99,znfrac*zVexc/zvpart)
 
-                   IF(zvfrac < 0.) WRITE(*,*) 'Error aerosol 0'
+                   IF(zvfrac < 0.) STOP 'Error aerosol 0'
                    !-- update bin
                    mm = kk+1
                    !-- volume
@@ -136,10 +136,7 @@ CONTAINS
              END DO ! - kk
 
              count = count + 1
-             IF (count > 100) THEN
-                WRITE(*,*) 'WARNING: Aerosol bin update not converged'
-                EXIT
-             END IF
+             IF (count > 100) STOP 'Error: Aerosol bin update not converged'
 
           END DO ! - within bins
 
@@ -204,7 +201,7 @@ CONTAINS
                    !zvfrac = min(zvfrac,1.)
                    zvfrac = MIN(0.99,znfrac*zVexc/zvpart)
 
-                   IF(zvfrac < 0.) WRITE(*,*) 'Error cloud 0'
+                   IF(zvfrac < 0.) STOP 'Error cloud 0'
 
                    !-- volume
                    pcloud(ii,jj,mm)%volc(:) = pcloud(ii,jj,mm)%volc(:)     &
@@ -230,19 +227,7 @@ CONTAINS
              END DO !kk
 
              count = count + 1
-             IF (count > 100) THEN
-                WRITE(*,*) 'WARNING: Cloud bin update not converged'
-                WRITE(*,*) pcloud(ii,jj,1:7)%numc
-                WRITE(*,*) pcloud(ii,jj,1:7)%volc(1)
-                WRITE(*,*) pcloud(ii,jj,1:7)%volc(2)
-                WRITE(*,*) pcloud(ii,jj,1:7)%volc(3)
-                WRITE(*,*) pcloud(ii,jj,1:7)%volc(4)
-                WRITE(*,*) pcloud(ii,jj,1:7)%volc(5)
-                WRITE(*,*) pcloud(ii,jj,1:7)%volc(6)
-                WRITE(*,*) pcloud(ii,jj,1:7)%volc(7)
-                WRITE(*,*) pcloud(ii,jj,1:7)%volc(8)
-                EXIT
-             END IF
+             IF (count > 100) STOP 'Error: Cloud bin update not converged'
 
           END DO !within_bins
 
@@ -339,12 +324,7 @@ CONTAINS
              END DO !kk
 
              count = count + 1
-             IF (count > 100) THEN
-                WRITE(*,*) 'WARNING: precipitation bin update not converged'
-                WRITE(*,'(7ES4.1E3)') pprecp(ii,jj,ira:fra)%numc
-                WRITE(*,'(7ES4.1E3)') pprecp(ii,jj,ira:fra)%volc(8)
-                EXIT
-             END IF
+             IF (count > 100) STOP 'Error: precipitation bin update not converged'
 
           END DO !within_bins
 
@@ -437,29 +417,7 @@ CONTAINS
              END DO !kk
 
              count = count + 1
-             IF (count > 100) THEN
-                WRITE(*,*) 'WARNING: Ice bin update not converged'
-                WRITE(*,*) 'numc'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%numc
-                WRITE(*,*) 'volc'
-                WRITE(*,*) 'SO4'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%volc(1)
-                WRITE(*,*) 'OC'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%volc(2)
-                WRITE(*,*) 'BC'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%volc(3)
-                WRITE(*,*) 'DU'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%volc(4)
-                WRITE(*,*) 'SS'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%volc(5)
-                WRITE(*,*) 'NO'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%volc(6)
-                WRITE(*,*) 'NH'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%volc(7)
-                WRITE(*,*) 'H2O'
-                WRITE(*,'(7ES10.1E3)') pice(ii,jj,1:7)%volc(8)
-                EXIT
-             END IF
+             IF (count > 100) STOP 'Error: Ice bin update not converged'
 
           END DO !within_bins
 
@@ -555,12 +513,7 @@ CONTAINS
              END DO !kk
 
              count = count + 1
-             IF (count > 100) THEN
-                WRITE(*,*) 'WARNING: snow bin update not converged'
-                WRITE(*,*) psnow(ii,jj,isa:fsa)%numc
-                WRITE(*,*) psnow(ii,jj,isa:fsa)%volc(8)
-                EXIT
-             END IF
+             IF (count > 100) STOP 'Error: snow bin update not converged'
 
           END DO !within_bins
 

--- a/src/src_salsa/mo_submctl.f90
+++ b/src/src_salsa/mo_submctl.f90
@@ -6,7 +6,6 @@ MODULE mo_submctl
 
   PRIVATE
 
-  !M7 and SALSA
   PUBLIC :: lsdistupdate,nsnucl
 
   PUBLIC :: debug
@@ -106,10 +105,6 @@ MODULE mo_submctl
      INTEGER :: par  ! Index for corresponding parallel distribution
   END TYPE t_parallelbin
 
-  !--- 1) Define and pre-set switches for the processes of M7: -----------------------
-
-  !--- Physical:
-  !Switches for both M7 and SALSA aerosol microphysical processes
   LOGICAL :: nldebug      = .FALSE., & ! debuggin output
              debug
 
@@ -185,15 +180,10 @@ MODULE mo_submctl
 
   LOGICAL :: lsdistupdate = .TRUE.  ! Perform the size distribution update
 
-  ! 1) Switches for M7 aerosol microphysical processes ------------------------
+  ! 1) Switches for aerosol microphysical processes ------------------------
   INTEGER, PARAMETER :: nmod = 7
 
-  INTEGER :: nsnucl     = 0         ! Choice of the H2SO4/H2O nucleation scheme:
-                                    ! M7:
-                                    ! nsnucl = 0 off
-                                    !        = 1 Vehkamaeki et al., JGR 2002
-                                    !        = 2 Kazil and Lovejoy, ACP 2007
-                                    ! SALSA:
+  INTEGER :: nsnucl     = 0         ! Choice of the nucleation scheme:
                                     ! 0 = off   
                                     ! 1 = binary nucleation
                                     ! 2 = activation type nucleation
@@ -330,6 +320,7 @@ MODULE mo_submctl
 
   REAL, PARAMETER ::     & ! molar mass [kg/mol]
    msu = 98.08e-3,        & ! sulphate
+   !msu = 132.14e-3,        & ! ammonium sulphate (for ASCOS simulations) TR
    mno = 62.01e-3,        & ! HNO3
    mnh = 18.04e-3,        & ! NH3
    moc = 150.e-3,         & ! organic carbon
@@ -341,6 +332,7 @@ MODULE mo_submctl
                                !
                                ! densities [kg/m3]
    rhosu = 1830.,         & ! sulphate
+   !rhosu = 1770.,         & ! ammoniun sulphate (for ASCOS simulations) TR
    rhono = 1479.,         & ! HNO3
    rhonh = 1530.,         & ! NH3
    rhooc = 2000.,         & ! organic carbon


### PR DESCRIPTION
Removed irrelevant comments (in Finnish), non-standard fortran code (problems with Cray compiler) and unused functions and parts of the code. Some inefficient but working functions were also updated. Advection is now calculated only for non-zero arrays. Concentration limits for aerosol and cloud species (nlim) and precipitation, ice and snow (prlim) are now consistent. prlim was set to 1e-6 #/kg (used to be 1e-40 #/kg). Improved the radiation code in merging background soundings and LES model inputs.